### PR TITLE
Adds config to enable template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
For the templates to be shown up on issue creation, this config file is needed.