### PR TITLE
Add list of previous and current contributors

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -1,8 +1,34 @@
 ## Acknowledgements
 
-### Current Participants of the WCAG2ICT Task Force
+### Participants of the WCAG2ICT Task Force Active in the Development of this Document
+* Shadi Abou-Zahra (Amazon)
+* Charles Adams (Oracle Corporation)
+* Bruce Bailey (U.S. Access Board)
+* Fernanda Bonnin (Microsoft)
+* Devanshu Chandra (Deque Systems, Inc.)
+* Michael Cooper (W3C)
+* Phil Day (NCR)
+* Mitchell Evan (TPGi)
+* Olivia Hogan-Stark (NCR)
+* Thorsten Katzmann (IBM)
+* Chris Loiselle (Oracle Corporation)
+* Loïc Martínez Normand (Universidad Politécnica de Madrid) 
+* Laura Miller (TPGi)
+* Daniel Montalvo (W3C)
+* Mary Jo Mueller (IBM)
+* Sam Ogami (HP Inc.)
+* Mike Pluke (Invited expert)
+* Shawn Thompson (Shared Services Canada)
+* Bryan Trogdon (Google LLC)
+* Gregg Vanderheiden (Raising the Floor)
 
-### Current participants in the WCAG Working Group
+### Participants in the AG Working Group that Actively Reviewed and Contributed
+<div class="ednote">This list will be updated as AG WG reviews and contributions are done.</div>
+* Jonathan Avila (Level Access)
+* Detlev Fischer (Invited expert)
+* Patrick Lauke (TetraLogical)
+* Lisa Seeman-Kestenbaum (Invited Expert)
 
 ### Previous Contributors
+The following people contributed to the development of the 2013 WCAG2ICT Note. 
 Shadi Abou-Zahra, Bruce Bailey, Judy Brewer, Michael Cooper, Pierce Crowell, Allen Hoffman, Kiran Kaja, Andrew Kirkpatrick, Peter Korn, Alex Li, David MacDonald, Mary Jo Mueller, Loïc Martínez Normand, Mike Pluke, Janina Sajka, Andi Snow-Weaver, Gregg Vanderheiden

--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -30,5 +30,6 @@
 * Patrick Lauke (TetraLogical)
 
 ### Previous Contributors
-The following people contributed to the development of the 2013 WCAG2ICT Note. 
+The following people contributed to the development of the 2013 WCAG2ICT Note.
+
 Shadi Abou-Zahra, Bruce Bailey, Judy Brewer, Michael Cooper, Pierce Crowell, Allen Hoffman, Kiran Kaja, Andrew Kirkpatrick, Peter Korn, Alex Li, David MacDonald, Mary Jo Mueller, Loïc Martínez Normand, Mike Pluke, Janina Sajka, Andi Snow-Weaver, Gregg Vanderheiden

--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -24,10 +24,10 @@
 
 ### Participants in the AG Working Group that Actively Reviewed and Contributed
 <div class="ednote">This list will be updated as AG WG reviews and contributions are done.</div>
+
 * Jonathan Avila (Level Access)
 * Detlev Fischer (Invited expert)
 * Patrick Lauke (TetraLogical)
-* Lisa Seeman-Kestenbaum (Invited Expert)
 
 ### Previous Contributors
 The following people contributed to the development of the 2013 WCAG2ICT Note. 

--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -1,8 +1,8 @@
 ## Acknowledgements
 
-### Previous Contributors
-
 ### Current Participants of the WCAG2ICT Task Force
 
 ### Current participants in the WCAG Working Group
 
+### Previous Contributors
+Shadi Abou-Zahra, Bruce Bailey, Judy Brewer, Michael Cooper, Pierce Crowell, Allen Hoffman, Kiran Kaja, Andrew Kirkpatrick, Peter Korn, Alex Li, David MacDonald, Mary Jo Mueller, Loïc Martínez Normand, Mike Pluke, Janina Sajka, Andi Snow-Weaver, Gregg Vanderheiden


### PR DESCRIPTION
Obtained list from the participants in the WCAG2ICT TF. This is for issue #105.