### PR TITLE
Fix formatting inside of Notes and broken links

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -21,7 +21,9 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.1.1](http://www.w3.org/WAI/WCAG22/Understanding/non-text-content#intent) (also provided below).
 
-<div class="note">CAPTCHAs do not currently appear outside of the Web. However, if they do appear, this guidance is accurate.</div>
+<div class="note">
+
+CAPTCHAs do not currently appear outside of the Web. However, if they do appear, this guidance is accurate.</div>
 <div class="note">
     
 See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
@@ -53,7 +55,7 @@ This applies directly as written, and as described in [Intent from Understanding
 
 <div class="note">
     
-    The WCAG 2.2 definition of “[captions](http://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “in some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
+The WCAG 2.2 definition of “[captions](http://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “in some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
 
 ##### audio-description-or-media-alternative-prerecorded
 
@@ -67,7 +69,7 @@ The WCAG 2.2 definition of “[audio description](http://www.w3.org/TR/WCAG22/#d
 <div class="note">Secondary or alternate audio tracks are commonly used for this purpose.</div>
 <div class="note">
     
-    See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### captions-live
 
@@ -77,7 +79,7 @@ This applies directly as written, and as described in [Intent from Understanding
 
 <div class="note">
     
-    The WCAG 2.2 definition of “[captions](http://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “In some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
+The WCAG 2.2 definition of “[captions](http://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “In some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
 
 ##### audio-description-prerecorded
 
@@ -142,14 +144,11 @@ This applies directly as written, and as described in Intent from [Understanding
 
 <div class="note">
 
-Non-web software and non-web documents that do not provide attributes that support identifying the expected meaning for the form input data, are not in scope for this success criterion.
-</div>
-
+Non-web software and non-web documents that do not provide attributes that support identifying the expected meaning for the form input data, are not in scope for this success criterion.</div>
 <div class="note">
 
 For non-web software and non-web documents that present input fields, the terms for the input purposes would be the equivalent terms provided by the technology used.
 </div>
-
 <div class="note"> 
 
 See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).
@@ -197,7 +196,10 @@ This applies directly as written, and as described in [Intent from Understanding
 [Content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) for which there are software players, viewers or editors with a 200 percent zoom feature would automatically meet this success criterion when used with such players, unless the content will not work with zoom.</div>
 <div class="note">
     
-The Intent section refers to the ability to allow users to enlarge the text on screen at least up to 200% without needing to use [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at). This means that the application provides some means for enlarging the text 200% (zoom or otherwise) without loss of [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) or functionality or that the application works with the platform features that meet this requirement.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+The Intent section refers to the ability to allow users to enlarge the text on screen at least up to 200% without needing to use [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at). This means that the application provides some means for enlarging the text 200% (zoom or otherwise) without loss of [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) or functionality or that the application works with the platform features that meet this requirement.</div>
+<div class="note">
+
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### images-of-text
 
@@ -447,7 +449,7 @@ With these substitutions, this success criterion would read:
 
 <div class="note">
     
-See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.).</div><div class="note">
+See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div><div class="note">
 
 The definitions of “[set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents)” and “[set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs)” in the Key Terms section if the Introduction are predicated on the ability to navigate from each element of the set to each other, and navigation is a type of locating. So the mechanism used to navigate between elements of the set will be one way of locating information in the set. Non-web environments, generally major operating systems with browse and search capabilities, often provide infrastructure and tools that provide mechanisms for locating content in a set of non-web documents or a set of software programs. For example, it may be possible to browse through the files or programs that make up a set, or search within members of the set for the names of other members. A file directory would be the equivalent of a site map for documents in a set, and a search function in a file system would be equivalent to a web search function for web pages. Such facilities may provide additional ways of locating information in the set.</div>
 <div class="note">
@@ -642,7 +644,9 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.3.1](http://www.w3.org/WAI/WCAG22/Understanding/error-identification#intent) (also provided below).
 
-<div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### labels-or-instructions
 

--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -407,7 +407,7 @@ This applies directly as written, and as described in [Intent from Understanding
 
 With this substitution, it would read:
 
-**2.4.2 Page Titled:** <INS>[Non-web documents](#dfn-non-web-documents) or [software](#dfn-software)</INS> have titles that describe topic or purpose. (Level A)
+**2.4.2 Page Titled:** <INS>[Non-web documents](#document) or [software](#dfn-software)</INS> have titles that describe topic or purpose. (Level A)
 
 <div class="note">
     
@@ -446,7 +446,7 @@ With these substitutions, this success criterion would read:
 
 (for non-web documents)
 
-**2.4.5 Multiple Ways:** More than one way is available to locate a <INS>[non-web document](#document)</INS> within a [set of <INS>non-web documents</INS>](#set-of-non-web-documents) except where the <INS>non-web document</INS> is the result of, or a step in, a process.
+**2.4.5 Multiple Ways:** More than one way is available to locate a <INS>[non-web document](#document)</INS> within a [set of <INS>non-web documents</INS>](#set-of-documents) except where the <INS>non-web document</INS> is the result of, or a step in, a process.
 
 (for software programs)
 
@@ -598,7 +598,7 @@ With these substitutions, this success criterion would read:
 
 (for non-web documents)
 
-**3.2.3 Consistent Navigation:** Navigational mechanisms that are repeated on multiple <INS>[non-web documents](#document)</INS> within a [set of <INS>non-web documents</INS>](#set-of-non-web-documents) occur in the same relative order each time they are repeated, unless a change is initiated by the user.
+**3.2.3 Consistent Navigation:** Navigational mechanisms that are repeated on multiple <INS>[non-web documents](#document)</INS> within a [set of <INS>non-web documents</INS>](#set-of-documents) occur in the same relative order each time they are repeated, unless a change is initiated by the user.
 
 (for software programs)
 

--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -19,14 +19,14 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 ###### Guidance When Applying Success Criterion 1.1.1 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.1.1](http://www.w3.org/WAI/WCAG22/Understanding/non-text-content#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.1.1](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content#intent) (also provided below).
 
 <div class="note">
 
 CAPTCHAs do not currently appear outside of the Web. However, if they do appear, this guidance is accurate.</div>
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 #### time-based-media
 
@@ -38,58 +38,63 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 ###### Guidance When Applying Success Criterion 1.2.1 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.1](http://www.w3.org/WAI/WCAG22/Understanding/audio-only-and-video-only-prerecorded#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.1](https://www.w3.org/WAI/WCAG22/Understanding/audio-only-and-video-only-prerecorded#intent) (also provided below).
 
 <div class="note">
     
-The alternative can be provided directly in the [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) or [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) – or provided in an alternate version that meets the success criteria.</div>
+The alternative can be provided directly in the [non-web document](#document) or [software](#software) – or provided in an alternate version that meets the success criteria.</div>
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ##### captions-prerecorded
 
 ###### Guidance When Applying Success Criterion 1.2.2 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.2](http://www.w3.org/WAI/WCAG22/Understanding/captions-prerecorded#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.2](https://www.w3.org/WAI/WCAG22/Understanding/captions-prerecorded#intent) (also provided below).
 
 <div class="note">
     
-The WCAG 2.2 definition of “[captions](http://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “in some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
+The WCAG 2.2 definition of “[captions](https://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “in some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](#content-on-and-off-the-web)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
 
 ##### audio-description-or-media-alternative-prerecorded
 
 ###### Guidance When Applying Success Criterion 1.2.3 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.3](http://www.w3.org/WAI/WCAG22/Understanding/audio-description-or-media-alternative-prerecorded#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.3](https://www.w3.org/WAI/WCAG22/Understanding/audio-description-or-media-alternative-prerecorded#intent) (also provided below).
 
 <div class="note">
     
-The WCAG 2.2 definition of “[audio description](http://www.w3.org/TR/WCAG22/#dfn-audio-descriptions)” says that “audio description” is “also called ‘video description’ and ‘descriptive narration’”.</div>
-<div class="note">Secondary or alternate audio tracks are commonly used for this purpose.</div>
+The WCAG 2.2 definition of “[audio description](https://www.w3.org/TR/WCAG22/#dfn-audio-descriptions)” says that “audio description” is “also called ‘video description’ and ‘descriptive narration’”.</div>
+<div class="note">
+
+Secondary or alternate audio tracks are commonly used for this purpose.</div>
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](https://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### captions-live
 
 ###### Guidance When Applying Success Criterion 1.2.4 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.4](http://www.w3.org/WAI/WCAG22/Understanding/captions-live#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.4](https://www.w3.org/WAI/WCAG22/Understanding/captions-live#intent) (also provided below).
 
 <div class="note">
     
-The WCAG 2.2 definition of “[captions](http://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “In some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
+The WCAG 2.2 definition of “[captions](https://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “In some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](#content-on-and-off-the-web)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
 
 ##### audio-description-prerecorded
 
 ###### Guidance When Applying Success Criterion 1.2.5 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.5](http://www.w3.org/WAI/WCAG22/Understanding/audio-description-prerecorded#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.5](https://www.w3.org/WAI/WCAG22/Understanding/audio-description-prerecorded#intent) (also provided below).
 
 <div class="note">
     
-The WCAG 2.2 definition of “[audio description](http://www.w3.org/TR/WCAG22/#dfn-audio-descriptions)” says that audio description is “also called ‘video description’ and ‘descriptive narration’”.</div><div class="note">Secondary or alternate audio tracks are commonly used for this purpose.</div>
+The WCAG 2.2 definition of “[audio description](https://www.w3.org/TR/WCAG22/#dfn-audio-descriptions)” says that audio description is “also called ‘video description’ and ‘descriptive narration’”.</div>
+<div class="note">
+
+Secondary or alternate audio tracks are commonly used for this purpose.</div>
 
 #### adaptable
 
@@ -101,36 +106,36 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 ###### Guidance When Applying Success Criterion 1.3.1 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.1](http://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.1](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships#intent) (also provided below).
 
 <div class="note">
     
-In software, programmatic determinability is best achieved through the use of [accessibility services provided by platform software](http://w3c.github.io/wcag2ict/#wcag2ict-def_accessibility-services) to enable interoperability between software and assistive technologies and accessibility features of software.</div>
+In software, programmatic determinability is best achieved through the use of [accessibility services provided by platform software](#accessibility-services-of-platform-software) to enable interoperability between software and assistive technologies and accessibility features of software.</div>
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ##### meaningful-sequence
 
 ###### Guidance When Applying Success Criterion 1.3.2 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.2](http://www.w3.org/WAI/WCAG22/Understanding/meaningful-sequence#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.2](https://www.w3.org/WAI/WCAG22/Understanding/meaningful-sequence#intent) (also provided below).
 
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ##### sensory-characteristics
 
 ###### Guidance When Applying Success Criterion 1.3.3 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.3](http://www.w3.org/WAI/WCAG22/Understanding/sensory-characteristics#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.3](https://www.w3.org/WAI/WCAG22/Understanding/sensory-characteristics#intent) (also provided below).
 
 ##### orientation
 
 ###### Guidance When Applying Success Criterion 1.3.4 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.4](http://www.w3.org/WAI/WCAG22/Understanding/orientation#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.4](https://www.w3.org/WAI/WCAG22/Understanding/orientation#intent) (also provided below).
 
 <div class="note">
     
@@ -140,7 +145,7 @@ Content that is only used on hardware that is fixed in place OR that has no sens
 
 ###### Guidance When Applying Success Criterion 1.3.5 to Non-Web Documents and Software
 
-This applies directly as written, and as described in Intent from [Understanding Success Criterion 1.3.5](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html) (also provided below).
+This applies directly as written, and as described in Intent from [Understanding Success Criterion 1.3.5](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html#intent) (also provided below).
 
 <div class="note">
 
@@ -151,7 +156,7 @@ For non-web software and non-web documents that present input fields, the terms 
 </div>
 <div class="note"> 
 
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).
+See also the discussion on [Closed Functionality](#closed-functionality).
 </div>
 
 #### distinguishable
@@ -164,52 +169,52 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 ###### Guidance When Applying Success Criterion 1.4.1 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.1](http://www.w3.org/WAI/WCAG22/Understanding/use-of-color#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.1](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color#intent) (also provided below).
 
 ##### audio-control
 
 ###### Guidance When Applying Success Criterion 1.4.2 to Non-Web Documents and Software
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.2](http://www.w3.org/WAI/WCAG22/Understanding/audio-control#intent) (also provided below), replacing “on a Web page” with “in a non-web document or software”, “any content” with “any part of a non-web document or software”, “whole page” with “whole document or software”, “on the Web page” with “in the document or software”, and removing “See Conformance Requirement 5: Non-Interference”.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.2](https://www.w3.org/WAI/WCAG22/Understanding/audio-control#intent) (also provided below), replacing “on a Web page” with “in a non-web document or software”, “any content” with “any part of a non-web document or software”, “whole page” with “whole document or software”, “on the Web page” with “in the document or software”, and removing “See Conformance Requirement 5: Non-Interference”.
 
 With these substitutions, it would read:
 
-**1.4.2 Audio Control:** If any audio <INS>in a [non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> plays automatically for more than 3 seconds, either a mechanism is available to pause or stop the audio, or a mechanism is available to control audio volume independently from the overall system volume level. (Level A)
+**1.4.2 Audio Control:** If any audio <INS>in a [non-web document](#document) or [software](#software)</INS> plays automatically for more than 3 seconds, either a mechanism is available to pause or stop the audio, or a mechanism is available to control audio volume independently from the overall system volume level. (Level A)
 
 <div class="note">
     
-Since any <INS>part of a [non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> that does not meet this success criterion can interfere with a user's ability to use the <INS>whole [document](#dfn-document) or [software](#dfn-software)</INS>, all [content](#dfn-content)<INS>in the [document](#dfn-document) or [software](#dfn-software)</INS> (whether or not it is used to meet other success criteria) must meet this success criterion.</div>
+Since any <INS>part of a [non-web document](#document) or [software](#software)</INS> that does not meet this success criterion can interfere with a user's ability to use the <INS>whole document or software</INS>, all [content](#content)<INS>in the document or software</INS> (whether or not it is used to meet other success criteria) must meet this success criterion.</div>
 
 ##### contrast-minimum
 
 ###### Guidance When Applying Success Criterion 1.4.3 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.3](http://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.3](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum#intent) (also provided below).
 
 ##### resize-text
 
 ###### Guidance When Applying Success Criterion 1.4.4 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.4](http://www.w3.org/WAI/WCAG22/Understanding/resize-text#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.4](https://www.w3.org/WAI/WCAG22/Understanding/resize-text#intent) (also provided below).
 
 <div class="note">
     
-[Content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) for which there are software players, viewers or editors with a 200 percent zoom feature would automatically meet this success criterion when used with such players, unless the content will not work with zoom.</div>
+[Content](#content) for which there are software players, viewers or editors with a 200 percent zoom feature would automatically meet this success criterion when used with such players, unless the content will not work with zoom.</div>
 <div class="note">
     
-The Intent section refers to the ability to allow users to enlarge the text on screen at least up to 200% without needing to use [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at). This means that the application provides some means for enlarging the text 200% (zoom or otherwise) without loss of [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) or functionality or that the application works with the platform features that meet this requirement.</div>
+The Intent section refers to the ability to allow users to enlarge the text on screen at least up to 200% without needing to use [assistive technologies](#dfn-assistive-technologies). This means that the application provides some means for enlarging the text 200% (zoom or otherwise) without loss of [content](#content-on-and-off-the-web) or functionality or that the application works with the platform features that meet this requirement.</div>
 <div class="note">
 
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ##### images-of-text
 
 ###### Guidance When Applying Success Criterion 1.4.5 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.5](http://www.w3.org/WAI/WCAG22/Understanding/images-of-text#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.5](https://www.w3.org/WAI/WCAG22/Understanding/images-of-text#intent) (also provided below).
 
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ##### reflow
 <p class="ednote">This section is to be developed by the WCAG2ICT Task Force.</p>
@@ -239,28 +244,28 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 ###### Guidance When Applying Success Criterion 2.1.1 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.1.1](http://www.w3.org/WAI/WCAG22/Understanding/keyboard#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.1.1](https://www.w3.org/WAI/WCAG22/Understanding/keyboard#intent) (also provided below).
 
 <div class="note">
     
 This does not imply that software must directly support a keyboard or “keyboard interface”. Nor does it imply that software must provide a soft keyboard. Underlying platform software may provide device independent input services to applications that enable operation via a keyboard. Software that supports operation via such platform device independent services would be operable by a keyboard and would comply.</div>
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ##### no-keyboard-trap
 
 ###### Guidance When Applying Success Criterion 2.1.2 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.1.2](http://www.w3.org/WAI/WCAG22/Understanding/no-keyboard-trap#intent) (also provided below), replacing “page” and “Web page” with “non-web document or software” and removing “See Conformance Requirement 5: Non-Interference”.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.1.2](https://www.w3.org/WAI/WCAG22/Understanding/no-keyboard-trap#intent) (also provided below), replacing “page” and “Web page” with “non-web document or software” and removing “See Conformance Requirement 5: Non-Interference”.
 
 With these substitutions, it would read:
 
-**2.1.2 No Keyboard Trap:** If keyboard focus can be moved to a component of the <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> using a [keyboard interface](#dfn-keyboard-interface), then focus can be moved away from that component using only a keyboard interface, and, if it requires more than unmodified arrow or tab keys or other standard exit methods, the user is advised of the method for moving focus away. (Level A)
+**2.1.2 No Keyboard Trap:** If keyboard focus can be moved to a component of the <INS>[non-web document](#document) or [software](#software)</INS> using a [keyboard interface](#dfn-keyboard-interface), then focus can be moved away from that component using only a keyboard interface, and, if it requires more than unmodified arrow or tab keys or other standard exit methods, the user is advised of the method for moving focus away. (Level A)
 
 <div class="note">
     
-Since any content that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS>, all content on the <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div>
+Since any content that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web document](#document) or [software](#software)</INS>, all content on the <INS>non-web document or software</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div>
 <div class="note">
 
 Standard exit methods may vary by platform. For example, on many desktop platforms, the Escape key is a standard method for exiting.</div>
@@ -273,7 +278,7 @@ This applies directly as written, and as described in [Intent from Understanding
 
 <div class="note">
     
-The WCAG2ICT interpretation is that the WCAG definition of a keyboard shortcut does not include a long press of a key (2 seconds or more) or other accessibility features provided by the platform. See the [keyboard shortcut](https://w3c.github.io/wcag2ict/#dfn-keyboard-shortcuts) definition for more details.</div>
+The WCAG2ICT interpretation is that the WCAG definition of a keyboard shortcut does not include a long press of a key (2 seconds or more) or other accessibility features provided by the platform. See the [keyboard shortcut](#dfn-keyboard-shortcuts) definition for more details.</div>
 
 #### enough-time
 
@@ -285,11 +290,11 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 ###### Guidance When Applying Success Criterion 2.2.1 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.2.1](http://www.w3.org/WAI/WCAG22/Understanding/timing-adjustable#intent) (also provided below), replacing “the content” with “non-web documents or software”.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.2.1](https://www.w3.org/WAI/WCAG22/Understanding/timing-adjustable#intent) (also provided below), replacing “the content” with “non-web documents or software”.
 
 With this substitution, it would read:
 
-**2.2.1 Timing Adjustable:** For each time limit that is set by <INS>[non-web documents](#dfn-non-web-documents) or [software](#dfn-software)</INS>, at least one of the following is true: (Level A)
+**2.2.1 Timing Adjustable:** For each time limit that is set by <INS>[non-web documents](#document) or [software](#software)</INS>, at least one of the following is true: (Level A)
 
 *   **Turn off:** The user is allowed to turn off the time limit before encountering it; or
     
@@ -306,13 +311,13 @@ With this substitution, it would read:
 
 <div class="note">
     
-This success criterion helps ensure that users can complete tasks without unexpected changes in content or context that are a result of a time limit. This success criterion should be considered in conjunction with [Success Criterion 3.2.1](http://www.w3.org/TR/WCAG22/#on-focus), which puts limits on changes of content or context as a result of user action.</div>
+This success criterion helps ensure that users can complete tasks without unexpected changes in content or context that are a result of a time limit. This success criterion should be considered in conjunction with [Success Criterion 3.2.1](https://www.w3.org/TR/WCAG22/#on-focus), which puts limits on changes of content or context as a result of user action.</div>
 
 ##### pause-stop-hide
 
 ###### Guidance When Applying Success Criterion 2.2.2 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.2.2](http://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide#intent) (also provided below), replacing “page” and “Web page” with “non-web documents and software” and removing “See Conformance Requirement 5: Non-Interference” in Note 2 of the success criterion.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.2.2](https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide#intent) (also provided below), replacing “page” and “Web page” with “non-web documents and software” and removing “See Conformance Requirement 5: Non-Interference” in Note 2 of the success criterion.
 
 With this substitution, it would read:
 
@@ -325,19 +330,19 @@ With this substitution, it would read:
 
 <div class="note">
     
-For requirements related to flickering or flashing content, refer to [Guideline 2.3](http://www.w3.org/TR/WCAG22/#seizures-and-physical-reactions).</div>
+For requirements related to flickering or flashing content, refer to [Guideline 2.3](https://www.w3.org/TR/WCAG22/#seizures-and-physical-reactions).</div>
 <div class="note">
     
-Since any [content](#dfn-content) that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web documents](#dfn-non-web-documents) and [software](#dfn-software)</INS>, all content on the <INS>[non-web documents](#dfn-non-web-documents) and [software](#dfn-software)</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div>
+Since any [content](#content-on-and-off-the-web) that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web documents](#document) and [software](#dfn-software)</INS>, all content on the <INS>non-web documents and software</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div>
 <div class="note">
     
-[Content](#dfn-Content) that is updated periodically by software or that is streamed to the user agent is not required to preserve or present information that is generated or received between the initiation of the pause and resuming presentation, as this may not be technically possible, and in many situations could be misleading to do so.</div>
+[Content](#content-on-and-off-the-web) that is updated periodically by software or that is streamed to the user agent is not required to preserve or present information that is generated or received between the initiation of the pause and resuming presentation, as this may not be technically possible, and in many situations could be misleading to do so.</div>
 <div class="note">
     
-An animation that occurs as part of a preload phase or similar situation can be considered essential if interaction cannot occur during that phase for all users and if not indicating progress could confuse users or cause them to think that [content](#dfn-content) was frozen or broken.</div>
+An animation that occurs as part of a preload phase or similar situation can be considered essential if interaction cannot occur during that phase for all users and if not indicating progress could confuse users or cause them to think that [content](#content-on-and-off-the-web) was frozen or broken.</div>
 <div class="note">
     
-While the success criteria uses the term “information”, the WCAG 2.2 Intent section makes it clear that this is to be applied to all content. Any [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content), whether informative or decorative, that is updated automatically, blinks, or moves may create an accessibility barrier.</div>
+While the success criteria uses the term “information”, the WCAG 2.2 Intent section makes it clear that this is to be applied to all content. Any [content](#content-on-and-off-the-web), whether informative or decorative, that is updated automatically, blinks, or moves may create an accessibility barrier.</div>
 
 #### seizures-and-physical-reactions
 
@@ -349,15 +354,15 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 ##### Guidance When Applying Success Criterion 2.3.1 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.3.1](http://www.w3.org/WAI/WCAG22/Understanding/three-flashes-or-below-threshold#intent) (also provided below), replacing “Web pages” with “non-web documents or software” , “the whole page” with “the whole non-web document or software”, “the Web page” with “the non-web document or software”, and removing “See Conformance Requirement 5: Non-Interference”.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.3.1](https://www.w3.org/WAI/WCAG22/Understanding/three-flashes-or-below-threshold#intent) (also provided below), replacing “Web pages” with “non-web documents or software” , “the whole page” with “the whole non-web document or software”, “the Web page” with “the non-web document or software”, and removing “See Conformance Requirement 5: Non-Interference”.
 
 With these substitutions, it would read:
 
-**2.3.1 Three Flashes or Below Threshold:** <INS>[Non-web documents](#dfn-Non-web-documents) or [software](#dfn-software)</INS> do not contain anything that flashes more than three times in any one second period, or the [flash](#dfn-flash) is below the [general flash and red flash thresholds](#dfn-general-flash-and-red-flash-thresholds). (Level A)
+**2.3.1 Three Flashes or Below Threshold:** <INS>[Non-web documents](#document) or [software](#software)</INS> do not contain anything that flashes more than three times in any one second period, or the [flash](#dfn-flash) is below the [general flash and red flash thresholds](#dfn-general-flash-and-red-flash-thresholds). (Level A)
 
 <div class="note">
     
-Since any content that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS>, all content on the <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div>
+Since any content that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web document](#document) or [software](#software)</INS>, all content on the <INS>non-web document or software</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div>
 
 #### navigable
 
@@ -369,21 +374,21 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 ###### Guidance When Applying Success Criterion 2.4.1 to Non-Web Documents and Software
 
-This applies directly as written and described in [Intent from Understanding Success Criterion 2.4.1](http://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks#intent) (also provided below), replacing “Web pages” with “non-web documents in a set of non-web documents” or “software programs in a set of software programs” to explicitly state that the multiple documents (or software programs) are part of a set rather than any two documents or pieces of software.
+This applies directly as written and described in [Intent from Understanding Success Criterion 2.4.1](https://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks#intent) (also provided below), replacing “Web pages” with “non-web documents in a set of non-web documents” or “software programs in a set of software programs” to explicitly state that the multiple documents (or software programs) are part of a set rather than any two documents or pieces of software.
 
 With these substitutions, this success criterion would read:
 
 (for non-web documents)
 
-**2.4.1 Bypass Blocks:** A mechanism is available to bypass blocks of content that are repeated on multiple <INS>[non-web documents](#dfn-non-web-documents) in a [set of non-web documents](#dfn-set-of-non-web-documents)</INS>.
+**2.4.1 Bypass Blocks:** A mechanism is available to bypass blocks of content that are repeated on multiple <INS>[non-web documents](#document) in a [set of non-web documents](#set-of-documents)</INS>.
 
 (for software programs)
 
-**2.4.1 Bypass Blocks:** A mechanism is available to bypass blocks of content that are repeated on multiple <INS>[software programs](#dfn-software-programs) in a [set of software programs](#dfn-set-of-software-programs)</INS>.
+**2.4.1 Bypass Blocks:** A mechanism is available to bypass blocks of content that are repeated on multiple <INS>[software programs](#software) in a [set of software programs](#set-of-software-programs)</INS>.
 
 <div class="note">
     
-See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or pieces of software is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div>
+See [set of documents](#set-of-documents) and [set of software programs](#set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or pieces of software is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div>
 <div class="note">
     
 Individual documents or software programs (not in a set) would automatically meet this success criterion because this success criterion applies only to things that appear in a set.</div>
@@ -398,7 +403,7 @@ Many software user interface components have built-in mechanisms to navigate dir
 
 ###### Guidance When Applying Success Criterion 2.4.2 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.4.2](http://www.w3.org/WAI/WCAG22/Understanding/page-titled#intent) (also provided below) replacing “Web pages” with “non-web documents or software”.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.4.2](https://www.w3.org/WAI/WCAG22/Understanding/page-titled#intent) (also provided below) replacing “Web pages” with “non-web documents or software”.
 
 With this substitution, it would read:
 
@@ -406,26 +411,26 @@ With this substitution, it would read:
 
 <div class="note">
     
-As described in the WCAG intent (also provided below), the name of a [non-web software application](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) or [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) (e.g. document, media file, etc.) is a sufficient title if it describes the topic or purpose.</div>
+As described in the WCAG intent (also provided below), the name of a [non-web software application](#software) or [non-web document](#document) (e.g. document, media file, etc.) is a sufficient title if it describes the topic or purpose.</div>
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ##### focus-order
 
 ###### Guidance When Applying Success Criterion 2.4.3 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.4.3](http://www.w3.org/WAI/WCAG22/Understanding/focus-order#intent) (also provided below) replacing “a Web page” with “non-web documents or software”.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.4.3](https://www.w3.org/WAI/WCAG22/Understanding/focus-order#intent) (also provided below) replacing “a Web page” with “non-web documents or software”.
 
 With this substitution, it would read:
 
-**2.4.3 Focus Order:** If <INS>[non-web documents](#dfn-non-web-documents) or [software](#dfn-software)</INS> can be navigated sequentially and the navigation sequences affect meaning or operation, focusable components receive focus in an order that preserves meaning and operability. (Level A)
+**2.4.3 Focus Order:** If <INS>[non-web documents](#document) or [software](#software)</INS> can be navigated sequentially and the navigation sequences affect meaning or operation, focusable components receive focus in an order that preserves meaning and operability. (Level A)
 
 ##### link-purpose-in-context
 
 ###### Guidance When Applying Success Criterion 2.4.4 to Non-Web Documents and Software
 
-This applies directly as written and as described in [Intent from Understanding Success Criterion 2.4.4](http://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context#intent) (also provided below), replacing both “web page” and “page” with “non-web documents and software” in the Intent from Understanding Success Criterion 2.4.4.
+This applies directly as written and as described in [Intent from Understanding Success Criterion 2.4.4](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context#intent) (also provided below), replacing both “web page” and “page” with “non-web documents and software” in the Intent from Understanding Success Criterion 2.4.4.
 
 <div class="note">
     
@@ -435,23 +440,23 @@ In software, a “link” is any text string or image in the user interface outs
 
 ###### Guidance When Applying Success Criterion 2.4.5 to Non-Web Documents and Software
 
-This applies directly as written and described in [Intent from Understanding Success Criterion 2.4.5](http://www.w3.org/WAI/WCAG22/Understanding/multiple-ways#intent) (also provided below), replacing “Web page(s)” with “non-web document(s)” and “software program(s)”.
+This applies directly as written and described in [Intent from Understanding Success Criterion 2.4.5](https://www.w3.org/WAI/WCAG22/Understanding/multiple-ways#intent) (also provided below), replacing “Web page(s)” with “non-web document(s)” and “software program(s)”.
 
 With these substitutions, this success criterion would read:
 
 (for non-web documents)
 
-**2.4.5 Multiple Ways:** More than one way is available to locate a <INS>[non-web document](#dfn-non-web-document)</INS> within a [set of <INS>non-web documents</INS>](#dfn-set-of-non-web-documents) except where the <INS>[non-web document](#dfn-non-web-document)</INS> is the result of, or a step in, a process.
+**2.4.5 Multiple Ways:** More than one way is available to locate a <INS>[non-web document](#document)</INS> within a [set of <INS>non-web documents</INS>](#set-of-non-web-documents) except where the <INS>non-web document</INS> is the result of, or a step in, a process.
 
 (for software programs)
 
-**2.4.5 Multiple Ways:** More than one way is available to locate a <INS>[software program](#dfn-software-program)</INS> within a [set of <INS>software programs</INS>](#dfn-set-of-software-programs) except where the <INS>[software program](#dfn-software-program)</INS> is the result of, or a step in, a process.
+**2.4.5 Multiple Ways:** More than one way is available to locate a <INS>[software program](#software)</INS> within a [set of <INS>software programs</INS>](#dfn-set-of-software-programs) except where the <INS>software program</INS> is the result of, or a step in, a process.
 
 <div class="note">
     
-See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div><div class="note">
+See [set of documents](#set-of-documents) and [set of software programs](#set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div><div class="note">
 
-The definitions of “[set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents)” and “[set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs)” in the Key Terms section if the Introduction are predicated on the ability to navigate from each element of the set to each other, and navigation is a type of locating. So the mechanism used to navigate between elements of the set will be one way of locating information in the set. Non-web environments, generally major operating systems with browse and search capabilities, often provide infrastructure and tools that provide mechanisms for locating content in a set of non-web documents or a set of software programs. For example, it may be possible to browse through the files or programs that make up a set, or search within members of the set for the names of other members. A file directory would be the equivalent of a site map for documents in a set, and a search function in a file system would be equivalent to a web search function for web pages. Such facilities may provide additional ways of locating information in the set.</div>
+The definitions of “[set of documents](#set-of-documents)” and “[set of software programs](#set-of-software-programs)” in the Key Terms section of the Introduction are predicated on the ability to navigate from each element of the set to each other, and navigation is a type of locating. So the mechanism used to navigate between elements of the set will be one way of locating information in the set. Non-web environments, generally major operating systems with browse and search capabilities, often provide infrastructure and tools that provide mechanisms for locating content in a set of non-web documents or a set of software programs. For example, it may be possible to browse through the files or programs that make up a set, or search within members of the set for the names of other members. A file directory would be the equivalent of a site map for documents in a set, and a search function in a file system would be equivalent to a web search function for web pages. Such facilities may provide additional ways of locating information in the set.</div>
 <div class="note">
     
 An example of the use of “a software program that is part of process”, that would meet the exception for this Success Criterion, would be one where programs are interlinked but the interlinking depends on program A being used before program B, for validation or to initialize the dataset etc.</div>
@@ -460,23 +465,23 @@ An example of the use of “a software program that is part of process”, that 
 While some users may find it useful to have multiple ways to locate some groups of user interface elements within a document or software program, this is not required by the success criterion (and may pose difficulties in some situations).</div>
 <div class="note">
     
-The definitions of “[set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_-documents)” and “[set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs)” in WCAG2ICT require every item in the set to be independently reachable, and so nothing in such a set can be a “step in a process” that can't be reached any other way. The purpose of the exception—that items in a process are exempt from meeting this success criterion—is achieved by the definition of set.</div>
+The definitions of “[set of documents](#set-of-documents)” and “[set of software programs](#set-of-software-programs)” in WCAG2ICT require every item in the set to be independently reachable, and so nothing in such a set can be a “step in a process” that can't be reached any other way. The purpose of the exception—that items in a process are exempt from meeting this success criterion—is achieved by the definition of set.</div>
 
 ##### headings-and-labels
 
 ###### Guidance When Applying Success Criterion 2.4.6 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.4.6](http://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.4.6](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels#intent) (also provided below).
 
 <div class="note">
     
-In [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software), headings and labels are used to describe sections of [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) and controls respectively. In some cases it may be unclear whether a piece of static text is a heading or a label. But whether treated as a label or a heading, the requirement is the same: that if they are present they describe the topic or purpose of the item(s) they are associated with.</div>
+In [software](#software), headings and labels are used to describe sections of [content](#content-on-and-off-the-web) and controls respectively. In some cases it may be unclear whether a piece of static text is a heading or a label. But whether treated as a label or a heading, the requirement is the same: that if they are present they describe the topic or purpose of the item(s) they are associated with.</div>
 
 ##### focus-visible
 
 ###### Guidance When Applying Success Criterion 2.4.7 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.4.7](http://www.w3.org/WAI/WCAG22/Understanding/focus-visible#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.4.7](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible#intent) (also provided below).
 
 ##### focus-appearance
 <p class="ednote">This section is to be developed by the WCAG2ICT Task Force.</p>
@@ -527,24 +532,24 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 ###### Guidance When Applying Success Criterion 3.1.1 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.1.1](http://www.w3.org/WAI/WCAG22/Understanding/language-of-page#intent) (also provided below) replacing “each web page” with non-web documents or software.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.1.1](https://www.w3.org/WAI/WCAG22/Understanding/language-of-page#intent) (also provided below) replacing “each web page” with non-web documents or software.
 
 With these substitutions, it would read:
 
-**3.1.1 Language of Page:** The default [human language](#dfn-human-language) of <INS>[non-web documents](#dfn-non-web-documents) or [software](#dfn-software)</INS> can be [programmatically determined](#dfn-programmatically-determined). (Level A)
+**3.1.1 Language of Page:** The default [human language](#dfn-human-language) of <INS>[non-web documents](#document) or [software](#software)</INS> can be [programmatically determined](#dfn-programmatically-determined). (Level A)
 
 <div class="note">
     
-Where software platforms provide a “locale / language” setting, applications that use that setting and render their interface in that “locale / language” would comply with this success criterion. Applications that do not use the platform “locale / language” setting but instead use an [accessibility-supported](http://w3c.github.io/wcag2ict/#wcag2ict-def_accessibility-supported) method for exposing the human language of the [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) would also comply with this success criterion. Applications implemented in technologies where [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at) cannot determine the human language and that do not support the platform “locale / language” setting may not be able to meet this success criterion in that locale / language.</div>
+Where software platforms provide a “locale / language” setting, applications that use that setting and render their interface in that “locale / language” would comply with this success criterion. Applications that do not use the platform “locale / language” setting but instead use an [accessibility-supported](#dfn-accessibility-supported) method for exposing the human language of the [software](#software) would also comply with this success criterion. Applications implemented in technologies where [assistive technologies](#dfn-assistive-technologies) cannot determine the human language and that do not support the platform “locale / language” setting may not be able to meet this success criterion in that locale / language.</div>
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ##### language-of-parts
 
 ###### Guidance When Applying Success Criterion 3.1.2 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.1.2](http://www.w3.org/WAI/WCAG22/Understanding/language-of-parts#intent) (also provided below) replacing “content” with “non-web document or software”.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.1.2](https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts#intent) (also provided below) replacing “content” with “non-web document or software”.
 
 With these substitutions, it would read:
 
@@ -552,10 +557,10 @@ With these substitutions, it would read:
 
 <div class="note">
     
-There are some [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) and [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) technologies where there is no assistive technology supported method for marking the language for the different passages or phrases in the [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) or software, and it would not be possible to meet this success criterion with those technologies.</div>
+There are some [software](#software) and [non-web document](#document) technologies where there is no assistive technology supported method for marking the language for the different passages or phrases in the non-web document or software, and it would not be possible to meet this success criterion with those technologies.</div>
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 #### predictable
 
@@ -565,13 +570,13 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 With this substitution, this guideline would read:
 
-Guideline 3.2 Predictable: Make <INS>[non-web documents](#dfn-non-web-documents) or [software](#dfn-software)</INS> appear and operate in predictable ways.
+Guideline 3.2 Predictable: Make <INS>[non-web documents](#document) or [software](#software)</INS> appear and operate in predictable ways.
 
 ##### on-focus
 
 ###### Guidance When Applying Success Criterion 3.2.1 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.2.1](http://www.w3.org/WAI/WCAG22/Understanding/on-focus#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.2.1](https://www.w3.org/WAI/WCAG22/Understanding/on-focus#intent) (also provided below).
 
 <div class="note">
     
@@ -581,27 +586,27 @@ Some compound documents and their user agents are designed to provide significan
 
 ###### Guidance When Applying Success Criterion 3.2.2 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.2.2](http://www.w3.org/WAI/WCAG22/Understanding/on-input#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.2.2](https://www.w3.org/WAI/WCAG22/Understanding/on-input#intent) (also provided below).
 
 ##### consistent-navigation
 
 ###### Guidance When Applying Success Criterion 3.2.3 to Non-Web Documents and Software
 
-This applies directly as written and described in [Intent from Understanding Success Criterion 3.2.3](http://www.w3.org/WAI/WCAG22/Understanding/consistent-navigation#intent) (also provided below), replacing “web pages” with “non-web documents” and “software programs”.
+This applies directly as written and described in [Intent from Understanding Success Criterion 3.2.3](https://www.w3.org/WAI/WCAG22/Understanding/consistent-navigation#intent) (also provided below), replacing “web pages” with “non-web documents” and “software programs”.
 
 With these substitutions, this success criterion would read:
 
 (for non-web documents)
 
-**3.2.3 Consistent Navigation:** Navigational mechanisms that are repeated on multiple <INS>[non-web documents](#dfn-non-web-documents)</INS> within a [set of <INS>non-web documents</INS>](#dfn-set-of-non-web-documents) occur in the same relative order each time they are repeated, unless a change is initiated by the user.
+**3.2.3 Consistent Navigation:** Navigational mechanisms that are repeated on multiple <INS>[non-web documents](#document)</INS> within a [set of <INS>non-web documents</INS>](#set-of-non-web-documents) occur in the same relative order each time they are repeated, unless a change is initiated by the user.
 
 (for software programs)
 
-**3.2.3 Consistent Navigation:** Navigational mechanisms that are repeated on multiple <INS>[software programs](#dfn-software-programs)</INS> within a [set of <INS>software programs</INS>](#dfn-set-of-software-programs) occur in the same relative order each time they are repeated, unless a change is initiated by the user.
+**3.2.3 Consistent Navigation:** Navigational mechanisms that are repeated on multiple <INS>[software programs](#software)</INS> within a [set of <INS>software programs</INS>](#set-of-software-programs) occur in the same relative order each time they are repeated, unless a change is initiated by the user.
 
 <div class="note">
     
-See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software programs is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div>
+See [set of documents](#set-of-documents) and [set of software programs](#set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software programs is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div>
 <div class="note">
     
 Although not required by this success criterion, ensuring that navigation elements have consistent order when repeated _within_ non-web documents or software programs directly addresses user needs identified in the Intent section for this Success Criterion, and is generally considered best practice.</div>
@@ -610,13 +615,13 @@ Although not required by this success criterion, ensuring that navigation elemen
 
 ###### Guidance When Applying Success Criterion 3.2.4 to Non-Web Documents and Software
 
-This applies directly as written and described in [Intent from Understanding Success Criterion 3.2.4](http://www.w3.org/WAI/WCAG22/Understanding/consistent-identification#intent) (also provided below), replacing “web pages” with “non-web documents” and “software programs”.
+This applies directly as written and described in [Intent from Understanding Success Criterion 3.2.4](https://www.w3.org/WAI/WCAG22/Understanding/consistent-identification#intent) (also provided below), replacing “web pages” with “non-web documents” and “software programs”.
 
 With these substitutions, this success criterion would read:
 
 (for non-web documents)
 
-**3.2.4 Consistent Identification:** Components that have the [same functionality](#dfn-same-functionality) within a [set of <INS>non-web documents</INS>](#dfn-set-of-non-web-documents) are identified consistently.
+**3.2.4 Consistent Identification:** Components that have the [same functionality](#dfn-same-functionality) within a [set of <INS>non-web documents</INS>](#set-of-documents) are identified consistently.
 
 (for programs)
 
@@ -624,7 +629,7 @@ With these substitutions, this success criterion would read:
 
 <div class="note">
     
-See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software programs is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div>
+See [set of documents](#set-of-documents) and [set of software programs](#set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software programs is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div>
 <div class="note">
     
 Although not required by this success criterion, ensuring that component identification be consistent when they occur more than once _within_ non-web documents or software programs directly addresses user needs identified in the Intent section for this Success Criterion, and is generally considered best practice.</div>
@@ -642,33 +647,33 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 ###### Guidance When Applying Success Criterion 3.3.1 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.3.1](http://www.w3.org/WAI/WCAG22/Understanding/error-identification#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.3.1](https://www.w3.org/WAI/WCAG22/Understanding/error-identification#intent) (also provided below).
 
 <div class="note">
 
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ##### labels-or-instructions
 
 ###### Guidance When Applying Success Criterion 3.3.2 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.3.2](http://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.3.2](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions#intent) (also provided below).
 
 ##### error-suggestion
 
 ###### Guidance When Applying Success Criterion 3.3.3 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.3.3](http://www.w3.org/WAI/WCAG22/Understanding/error-suggestion#intent) (also provided below).
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.3.3](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion#intent) (also provided below).
 
 ##### error-prevention-legal-financial-data
 
 ###### Guidance When Applying Success Criterion 3.3.4 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.3.4](http://www.w3.org/WAI/WCAG22/Understanding/error-prevention-legal-financial-data#intent) (also provided below) replacing “web pages” with “non-web documents or software”.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.3.4](https://www.w3.org/WAI/WCAG22/Understanding/error-prevention-legal-financial-data#intent) (also provided below) replacing “web pages” with “non-web documents or software”.
 
 With this substitution, it would read:
 
-**3.3.4 Error Prevention (Legal, Financial, Data):** For <INS>[non-web documents](#dfn-non-web-documents) or [software](#dfn-software)</INS> that cause [legal commitments](#dfn-legal-commitments) or financial transactions for the user to occur, that modify or delete [user-controllable](#dfn-user-controllable) data in data storage systems, or that submit user test responses, at least one of the following is true: (Level AA)
+**3.3.4 Error Prevention (Legal, Financial, Data):** For <INS>[non-web documents](#document) or [software](#software)</INS> that cause [legal commitments](#dfn-legal-commitments) or financial transactions for the user to occur, that modify or delete [user-controllable](#dfn-user-controllable) data in data storage systems, or that submit user test responses, at least one of the following is true: (Level AA)
 
 1.  **Reversible:** Submissions are reversible.
     
@@ -706,36 +711,36 @@ Guideline 4.1 Compatible: Maximize compatibility with current and future <INS>[a
 
 ###### Guidance When Applying Success Criterion 4.1.1 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 4.1.1](http://www.w3.org/WAI/WCAG22/Understanding/parsing#intent) (also provided below), replacing “In content implemented using markup languages” with “For non-web documents or software that use markup languages, in such a way that the markup is separately exposed and available to assistive technologies and accessibility features of software or to a user-selectable user agent”.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 4.1.1](https://www.w3.org/WAI/WCAG22/Understanding/parsing#intent) (also provided below), replacing “In content implemented using markup languages” with “For non-web documents or software that use markup languages, in such a way that the markup is separately exposed and available to assistive technologies and accessibility features of software or to a user-selectable user agent”.
 
 With these substitutions, it would read:
 
-**4.1.1 Parsing:** <INS>For [non-web documents](#dfn-non-web-documents) or [software](#dfn-software) that use markup languages, in such a way that the markup is separately exposed and available to [assistive technologies](#dfn-assistive-technologies) and accessibility features of software or to a user-selectable [user agent](#dfn-user-agent)</INS>, elements have complete start and end tags, elements are nested according to their specifications, elements do not contain duplicate attributes, and any IDs are unique, except where the specifications allow these features. (Level A)
+**4.1.1 Parsing:** <INS>For [non-web documents](#document) or [software](#dsoftware) that use markup languages, in such a way that the markup is separately exposed and available to [assistive technologies](#dfn-assistive-technologies) and accessibility features of software or to a user-selectable [user agent](#user-agent)</INS>, elements have complete start and end tags, elements are nested according to their specifications, elements do not contain duplicate attributes, and any IDs are unique, except where the specifications allow these features. (Level A)
 
 <div class="note">
     
 Start and end tags that are missing a critical character in their formation, such as a closing angle bracket or a mismatched attribute value quotation mark are not complete.</div>
 <div class="note">
     
-Markup is not always available to [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at) or to user selectable [user agents](http://w3c.github.io/wcag2ict/#wcag2ict-def_useragent) such as browsers. Software sometimes uses markup languages internally for persistence of the software user interface, in ways where the markup is never available to assistive technology (either directly or through a document object model (DOM)), or to a user agent (such as a browser). In such cases, conformance to this provision would have no impact on accessibility as it can have for web content where it is exposed.</div>
+Markup is not always available to [assistive technologies](#dfn-assistive-technologies) or to user selectable [user agents](user-agent) such as browsers. Software sometimes uses markup languages internally for persistence of the software user interface, in ways where the markup is never available to assistive technology (either directly or through a document object model (DOM)), or to a user agent (such as a browser). In such cases, conformance to this provision would have no impact on accessibility as it can have for web content where it is exposed.</div>
 
-Examples of markup that is separately exposed and available to [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at) and to [user agents](http://w3c.github.io/wcag2ict/#wcag2ict-def_useragent) include: documents encoded in HTML, ODF, and OOXML. In these examples, the markup can be parsed entirely in two ways: (a) by assistive technologies which may directly open the document, (b) by assistive technologies using DOM APIs of user agents for these document formats.
+Examples of markup that is separately exposed and available to [assistive technologies](#dfn-assistive-technologies) and to [user agents](#user-agent) include: documents encoded in HTML, ODF, and OOXML. In these examples, the markup can be parsed entirely in two ways: (a) by assistive technologies which may directly open the document, (b) by assistive technologies using DOM APIs of user agents for these document formats.
 
-Examples of markup used internally for persistence of the software user interface that are never exposed to [assistive technology](http://w3c.github.io/wcag2ict/#wcag2ict-def_at) include but are not limited to: XUL, GladeXML, and FXML. In these examples assistive technology only interacts with the user interface of generated software.
+Examples of markup used internally for persistence of the software user interface that are never exposed to [assistive technology](#dfn-assistive-technologies) include but are not limited to: XUL, GladeXML, and FXML. In these examples assistive technology only interacts with the user interface of generated software.
 
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ##### name-role-value
 
 ###### Guidance When Applying Success Criterion 4.1.2 to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 4.1.2](http://www.w3.org/WAI/WCAG22/Understanding/name-role-value#intent) (also provided below), replacing the note with: “This success criterion is primarily for software developers who develop or use custom user interface components. For example, standard user interface components on most accessibility-supported platforms already meet this success criterion when used according to specification.”.
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 4.1.2](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value#intent) (also provided below), replacing the note with: “This success criterion is primarily for software developers who develop or use custom user interface components. For example, standard user interface components on most accessibility-supported platforms already meet this success criterion when used according to specification.”.
 
 With this substitution, it would read:
 
-**4.1.2 Name, Role, Value:** For all [user interface components](#dfn-user-interface-components) (including but not limited to: form elements, links and components generated by scripts), the [name](#dfn-name) and [role](#dfn-role) can be [programmatically determined](#dfn-programmatically-determined); states, properties, and values that can be set by the user can be [programmatically set](#dfn-programmatically-set); and notification of changes to these items is available to [user agents](#dfn-user-agents), including [assistive technologies](#dfn-assistive-technologies). (Level A)
+**4.1.2 Name, Role, Value:** For all [user interface components](#dfn-user-interface-components) (including but not limited to: form elements, links and components generated by scripts), the [name](#dfn-name) and [role](#dfn-role) can be [programmatically determined](#dfn-programmatically-determined); states, properties, and values that can be set by the user can be [programmatically set](#dfn-programmatically-set); and notification of changes to these items is available to [user agents](#user-agent), including [assistive technologies](#dfn-assistive-technologies). (Level A)
 
 <div class="note">
     
@@ -748,7 +753,7 @@ For conforming to this success criterion, it is usually best practice for softwa
 For document formats that support interoperability with assistive technology, standard user interface components often meet this success criterion when used according to the general design and accessibility guidance for the document format.</div>
 <div class="note">
     
-See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ##### status-messages
 <p class="ednote">This section is to be developed by the WCAG2ICT Task Force.</p>

--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -21,7 +21,10 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.1.1](http://www.w3.org/WAI/WCAG22/Understanding/non-text-content#intent) (also provided below).
 
-<div class="note">CAPTCHAs do not currently appear outside of the Web. However, if they do appear, this guidance is accurate.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">CAPTCHAs do not currently appear outside of the Web. However, if they do appear, this guidance is accurate.</div>
+<div class="note">
+    
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 #### time-based-media
 
@@ -35,7 +38,12 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.1](http://www.w3.org/WAI/WCAG22/Understanding/audio-only-and-video-only-prerecorded#intent) (also provided below).
 
-<div class="note">The alternative can be provided directly in the [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) or [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) – or provided in an alternate version that meets the success criteria.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+The alternative can be provided directly in the [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) or [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) – or provided in an alternate version that meets the success criteria.</div>
+<div class="note">
+    
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### captions-prerecorded
 
@@ -43,7 +51,9 @@ This applies directly as written, and as described in [Intent from Understanding
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.2](http://www.w3.org/WAI/WCAG22/Understanding/captions-prerecorded#intent) (also provided below).
 
-<div class="note">The WCAG 2.2 definition of “[captions](http://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “in some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
+<div class="note">
+    
+    The WCAG 2.2 definition of “[captions](http://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “in some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
 
 ##### audio-description-or-media-alternative-prerecorded
 
@@ -51,7 +61,13 @@ This applies directly as written, and as described in [Intent from Understanding
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.3](http://www.w3.org/WAI/WCAG22/Understanding/audio-description-or-media-alternative-prerecorded#intent) (also provided below).
 
-<div class="note">The WCAG 2.2 definition of “[audio description](http://www.w3.org/TR/WCAG22/#dfn-audio-descriptions)” says that “audio description” is “also called ‘video description’ and ‘descriptive narration’”.</div><div class="note">Secondary or alternate audio tracks are commonly used for this purpose.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+The WCAG 2.2 definition of “[audio description](http://www.w3.org/TR/WCAG22/#dfn-audio-descriptions)” says that “audio description” is “also called ‘video description’ and ‘descriptive narration’”.</div>
+<div class="note">Secondary or alternate audio tracks are commonly used for this purpose.</div>
+<div class="note">
+    
+    See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### captions-live
 
@@ -59,7 +75,9 @@ This applies directly as written, and as described in [Intent from Understanding
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.4](http://www.w3.org/WAI/WCAG22/Understanding/captions-live#intent) (also provided below).
 
-<div class="note">The WCAG 2.2 definition of “[captions](http://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “In some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
+<div class="note">
+    
+    The WCAG 2.2 definition of “[captions](http://www.w3.org/TR/WCAG22/#dfn-captions)” notes that “In some countries, captions are called subtitles”. They are also sometimes referred to as “subtitles for the hearing impaired.” Per the definition in WCAG 2.2, to meet this success criterion, whether called captions or subtitles, they would have to provide “synchronized visual and / or text alternative for both speech and non-speech audio information needed to understand the media [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content)” where non-speech information includes “sound effects, music, laughter, speaker identification and location”.</div>
 
 ##### audio-description-prerecorded
 
@@ -67,7 +85,9 @@ This applies directly as written, and as described in [Intent from Understanding
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.5](http://www.w3.org/WAI/WCAG22/Understanding/audio-description-prerecorded#intent) (also provided below).
 
-<div class="note">The WCAG 2.2 definition of “[audio description](http://www.w3.org/TR/WCAG22/#dfn-audio-descriptions)” says that audio description is “also called ‘video description’ and ‘descriptive narration’”.</div><div class="note">Secondary or alternate audio tracks are commonly used for this purpose.</div>
+<div class="note">
+    
+The WCAG 2.2 definition of “[audio description](http://www.w3.org/TR/WCAG22/#dfn-audio-descriptions)” says that audio description is “also called ‘video description’ and ‘descriptive narration’”.</div><div class="note">Secondary or alternate audio tracks are commonly used for this purpose.</div>
 
 #### adaptable
 
@@ -81,7 +101,12 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.1](http://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships#intent) (also provided below).
 
-<div class="note">In software, programmatic determinability is best achieved through the use of [accessibility services provided by platform software](http://w3c.github.io/wcag2ict/#wcag2ict-def_accessibility-services) to enable interoperability between software and assistive technologies and accessibility features of software.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+In software, programmatic determinability is best achieved through the use of [accessibility services provided by platform software](http://w3c.github.io/wcag2ict/#wcag2ict-def_accessibility-services) to enable interoperability between software and assistive technologies and accessibility features of software.</div>
+<div class="note">
+    
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### meaningful-sequence
 
@@ -89,7 +114,9 @@ This applies directly as written, and as described in [Intent from Understanding
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.2](http://www.w3.org/WAI/WCAG22/Understanding/meaningful-sequence#intent) (also provided below).
 
-<div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### sensory-characteristics
 
@@ -103,7 +130,9 @@ This applies directly as written, and as described in [Intent from Understanding
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.4](http://www.w3.org/WAI/WCAG22/Understanding/orientation#intent) (also provided below).
 
-<div class="note">Content that is only used on hardware that is fixed in place OR that has no sensor to detect or change the orientation is covered under the essential exception and not required to provide support for orientation changes.</div>
+<div class="note">
+    
+Content that is only used on hardware that is fixed in place OR that has no sensor to detect or change the orientation is covered under the essential exception and not required to provide support for orientation changes.</div>
 
 ##### identify-input-purpose
 
@@ -112,14 +141,17 @@ This applies directly as written, and as described in [Intent from Understanding
 This applies directly as written, and as described in Intent from [Understanding Success Criterion 1.3.5](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html) (also provided below).
 
 <div class="note">
+
 Non-web software and non-web documents that do not provide attributes that support identifying the expected meaning for the form input data, are not in scope for this success criterion.
 </div>
 
 <div class="note">
+
 For non-web software and non-web documents that present input fields, the terms for the input purposes would be the equivalent terms provided by the technology used.
 </div>
 
 <div class="note"> 
+
 See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).
 </div>
 
@@ -138,14 +170,15 @@ This applies directly as written, and as described in [Intent from Understanding
 ##### audio-control
 
 ###### Guidance When Applying Success Criterion 1.4.2 to Non-Web Documents and Software
-
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.2](http://www.w3.org/WAI/WCAG22/Understanding/audio-control#intent) (also provided below), replacing “on a Web page” with “in a non-web document or software”, “any content” with “any part of a non-web document or software”, “whole page” with “whole document or software”, “on the Web page” with “in the document or software”, and removing “See Conformance Requirement 5: Non-Interference”.
 
 With these substitutions, it would read:
 
 **1.4.2 Audio Control:** If any audio <INS>in a [non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> plays automatically for more than 3 seconds, either a mechanism is available to pause or stop the audio, or a mechanism is available to control audio volume independently from the overall system volume level. (Level A)
 
-<div class="note">Since any <INS>part of a [non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> that does not meet this success criterion can interfere with a user's ability to use the <INS>whole [document](#dfn-document) or [software](#dfn-software)</INS>, all [content](#dfn-content)<INS>in the [document](#dfn-document) or [software](#dfn-software)</INS> (whether or not it is used to meet other success criteria) must meet this success criterion.</div>
+<div class="note">
+    
+Since any <INS>part of a [non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> that does not meet this success criterion can interfere with a user's ability to use the <INS>whole [document](#dfn-document) or [software](#dfn-software)</INS>, all [content](#dfn-content)<INS>in the [document](#dfn-document) or [software](#dfn-software)</INS> (whether or not it is used to meet other success criteria) must meet this success criterion.</div>
 
 ##### contrast-minimum
 
@@ -159,7 +192,12 @@ This applies directly as written, and as described in [Intent from Understanding
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.4](http://www.w3.org/WAI/WCAG22/Understanding/resize-text#intent) (also provided below).
 
-<div class="note">[Content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) for which there are software players, viewers or editors with a 200 percent zoom feature would automatically meet this success criterion when used with such players, unless the content will not work with zoom.</div><div class="note">The Intent section refers to the ability to allow users to enlarge the text on screen at least up to 200% without needing to use [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at). This means that the application provides some means for enlarging the text 200% (zoom or otherwise) without loss of [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) or functionality or that the application works with the platform features that meet this requirement.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+[Content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) for which there are software players, viewers or editors with a 200 percent zoom feature would automatically meet this success criterion when used with such players, unless the content will not work with zoom.</div>
+<div class="note">
+    
+The Intent section refers to the ability to allow users to enlarge the text on screen at least up to 200% without needing to use [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at). This means that the application provides some means for enlarging the text 200% (zoom or otherwise) without loss of [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) or functionality or that the application works with the platform features that meet this requirement.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### images-of-text
 
@@ -167,7 +205,9 @@ This applies directly as written, and as described in [Intent from Understanding
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.4.5](http://www.w3.org/WAI/WCAG22/Understanding/images-of-text#intent) (also provided below).
 
-<div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### reflow
 <p class="ednote">This section is to be developed by the WCAG2ICT Task Force.</p>
@@ -199,7 +239,12 @@ In WCAG 2.2, the Guidelines are provided for framing and understanding the succe
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.1.1](http://www.w3.org/WAI/WCAG22/Understanding/keyboard#intent) (also provided below).
 
-<div class="note">This does not imply that software must directly support a keyboard or “keyboard interface”. Nor does it imply that software must provide a soft keyboard. Underlying platform software may provide device independent input services to applications that enable operation via a keyboard. Software that supports operation via such platform device independent services would be operable by a keyboard and would comply.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+This does not imply that software must directly support a keyboard or “keyboard interface”. Nor does it imply that software must provide a soft keyboard. Underlying platform software may provide device independent input services to applications that enable operation via a keyboard. Software that supports operation via such platform device independent services would be operable by a keyboard and would comply.</div>
+<div class="note">
+    
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### no-keyboard-trap
 
@@ -211,7 +256,12 @@ With these substitutions, it would read:
 
 **2.1.2 No Keyboard Trap:** If keyboard focus can be moved to a component of the <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> using a [keyboard interface](#dfn-keyboard-interface), then focus can be moved away from that component using only a keyboard interface, and, if it requires more than unmodified arrow or tab keys or other standard exit methods, the user is advised of the method for moving focus away. (Level A)
 
-<div class="note">Since any content that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS>, all content on the <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div><div class="note">Standard exit methods may vary by platform. For example, on many desktop platforms, the Escape key is a standard method for exiting.</div>
+<div class="note">
+    
+Since any content that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS>, all content on the <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div>
+<div class="note">
+
+Standard exit methods may vary by platform. For example, on many desktop platforms, the Escape key is a standard method for exiting.</div>
 
 ##### character-key-shortcuts
 
@@ -219,7 +269,9 @@ With these substitutions, it would read:
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.1.4](https://www.w3.org/WAI/WCAG22/Understanding/character-key-shortcuts.html) (also provided below).
 
-<div class="note">The WCAG2ICT interpretation is that the WCAG definition of a keyboard shortcut does not include a long press of a key (2 seconds or more) or other accessibility features provided by the platform. See the [keyboard shortcut](https://w3c.github.io/wcag2ict/#dfn-keyboard-shortcuts) definition for more details.</div>
+<div class="note">
+    
+The WCAG2ICT interpretation is that the WCAG definition of a keyboard shortcut does not include a long press of a key (2 seconds or more) or other accessibility features provided by the platform. See the [keyboard shortcut](https://w3c.github.io/wcag2ict/#dfn-keyboard-shortcuts) definition for more details.</div>
 
 #### enough-time
 
@@ -250,7 +302,9 @@ With this substitution, it would read:
 *   **20 Hour Exception:** The time limit is longer than 20 hours.
     
 
-<div class="note">This success criterion helps ensure that users can complete tasks without unexpected changes in content or context that are a result of a time limit. This success criterion should be considered in conjunction with [Success Criterion 3.2.1](http://www.w3.org/TR/WCAG22/#on-focus), which puts limits on changes of content or context as a result of user action.</div>
+<div class="note">
+    
+This success criterion helps ensure that users can complete tasks without unexpected changes in content or context that are a result of a time limit. This success criterion should be considered in conjunction with [Success Criterion 3.2.1](http://www.w3.org/TR/WCAG22/#on-focus), which puts limits on changes of content or context as a result of user action.</div>
 
 ##### pause-stop-hide
 
@@ -267,7 +321,21 @@ With this substitution, it would read:
 *   **Auto-updating:** For any auto-updating information that (1) starts automatically and (2) is presented in parallel with other content, there is a mechanism for the user to pause, stop, or hide it or to control the frequency of the update unless the auto-updating is part of an activity where it is essential.
     
 
-<div class="note">For requirements related to flickering or flashing content, refer to [Guideline 2.3](http://www.w3.org/TR/WCAG22/#seizures-and-physical-reactions).</div><div class="note">Since any [content](#dfn-content) that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web documents](#dfn-non-web-documents) and [software](#dfn-software)</INS>, all content on the <INS>[non-web documents](#dfn-non-web-documents) and [software](#dfn-software)</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div><div class="note">[Content](#dfn-Content) that is updated periodically by software or that is streamed to the user agent is not required to preserve or present information that is generated or received between the initiation of the pause and resuming presentation, as this may not be technically possible, and in many situations could be misleading to do so.</div><div class="note">An animation that occurs as part of a preload phase or similar situation can be considered essential if interaction cannot occur during that phase for all users and if not indicating progress could confuse users or cause them to think that [content](#dfn-content) was frozen or broken.</div><div class="note">While the success criteria uses the term “information”, the WCAG 2.2 Intent section makes it clear that this is to be applied to all content. Any [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content), whether informative or decorative, that is updated automatically, blinks, or moves may create an accessibility barrier.</div>
+<div class="note">
+    
+For requirements related to flickering or flashing content, refer to [Guideline 2.3](http://www.w3.org/TR/WCAG22/#seizures-and-physical-reactions).</div>
+<div class="note">
+    
+Since any [content](#dfn-content) that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web documents](#dfn-non-web-documents) and [software](#dfn-software)</INS>, all content on the <INS>[non-web documents](#dfn-non-web-documents) and [software](#dfn-software)</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div>
+<div class="note">
+    
+[Content](#dfn-Content) that is updated periodically by software or that is streamed to the user agent is not required to preserve or present information that is generated or received between the initiation of the pause and resuming presentation, as this may not be technically possible, and in many situations could be misleading to do so.</div>
+<div class="note">
+    
+An animation that occurs as part of a preload phase or similar situation can be considered essential if interaction cannot occur during that phase for all users and if not indicating progress could confuse users or cause them to think that [content](#dfn-content) was frozen or broken.</div>
+<div class="note">
+    
+While the success criteria uses the term “information”, the WCAG 2.2 Intent section makes it clear that this is to be applied to all content. Any [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content), whether informative or decorative, that is updated automatically, blinks, or moves may create an accessibility barrier.</div>
 
 #### seizures-and-physical-reactions
 
@@ -285,7 +353,9 @@ With these substitutions, it would read:
 
 **2.3.1 Three Flashes or Below Threshold:** <INS>[Non-web documents](#dfn-Non-web-documents) or [software](#dfn-software)</INS> do not contain anything that flashes more than three times in any one second period, or the [flash](#dfn-flash) is below the [general flash and red flash thresholds](#dfn-general-flash-and-red-flash-thresholds). (Level A)
 
-<div class="note">Since any content that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS>, all content on the <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div>
+<div class="note">
+    
+Since any content that does not meet this success criterion can interfere with a user's ability to use the whole <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS>, all content on the <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> (whether it is used to meet other success criteria or not) must meet this success criterion.</div>
 
 #### navigable
 
@@ -309,7 +379,18 @@ With these substitutions, this success criterion would read:
 
 **2.4.1 Bypass Blocks:** A mechanism is available to bypass blocks of content that are repeated on multiple <INS>[software programs](#dfn-software-programs) in a [set of software programs](#dfn-set-of-software-programs)</INS>.
 
-<div class="note">See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or pieces of software is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div><div class="note">Individual documents or software programs (not in a set) would automatically meet this success criterion because this success criterion applies only to things that appear in a set.</div><div class="note">Although not required by the success criterion, being able to bypass blocks of content that are repeated _within_ non-web documents or software directly addresses user needs identified in the Intent section for this Success Criterion, and is generally considered best practice.</div><div class="note">Many software user interface components have built-in mechanisms to navigate directly to / among them, which also have the effect of skipping over or bypassing blocks of content.</div>
+<div class="note">
+    
+See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or pieces of software is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div>
+<div class="note">
+    
+Individual documents or software programs (not in a set) would automatically meet this success criterion because this success criterion applies only to things that appear in a set.</div>
+<div class="note">
+    
+Although not required by the success criterion, being able to bypass blocks of content that are repeated _within_ non-web documents or software directly addresses user needs identified in the Intent section for this Success Criterion, and is generally considered best practice.</div>
+<div class="note">
+    
+Many software user interface components have built-in mechanisms to navigate directly to / among them, which also have the effect of skipping over or bypassing blocks of content.</div>
 
 ##### page-titled
 
@@ -319,9 +400,14 @@ This applies directly as written, and as described in [Intent from Understanding
 
 With this substitution, it would read:
 
-**2.4.2 Page Titled:** <INS>[Non-web documents](#dfn-Non-web-documents) or [software](#dfn-software)</INS> have titles that describe topic or purpose. (Level A)
+**2.4.2 Page Titled:** <INS>[Non-web documents](#dfn-non-web-documents) or [software](#dfn-software)</INS> have titles that describe topic or purpose. (Level A)
 
-<div class="note">As described in the WCAG intent (also provided below), the name of a [non-web software application](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) or [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) (e.g. document, media file, etc.) is a sufficient title if it describes the topic or purpose.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+As described in the WCAG intent (also provided below), the name of a [non-web software application](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) or [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) (e.g. document, media file, etc.) is a sufficient title if it describes the topic or purpose.</div>
+<div class="note">
+    
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### focus-order
 
@@ -339,7 +425,9 @@ With this substitution, it would read:
 
 This applies directly as written and as described in [Intent from Understanding Success Criterion 2.4.4](http://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context#intent) (also provided below), replacing both “web page” and “page” with “non-web documents and software” in the Intent from Understanding Success Criterion 2.4.4.
 
-<div class="note">In software, a “link” is any text string or image in the user interface outside a user interface control that behaves like a hypertext link. This does not include general user interface controls or buttons. (An OK button, for example, would not be a link.)</div>
+<div class="note">
+    
+In software, a “link” is any text string or image in the user interface outside a user interface control that behaves like a hypertext link. This does not include general user interface controls or buttons. (An OK button, for example, would not be a link.)</div>
 
 ##### multiple-ways
 
@@ -357,7 +445,20 @@ With these substitutions, this success criterion would read:
 
 **2.4.5 Multiple Ways:** More than one way is available to locate a <INS>[software program](#dfn-software-program)</INS> within a [set of <INS>software programs</INS>](#dfn-set-of-software-programs) except where the <INS>[software program](#dfn-software-program)</INS> is the result of, or a step in, a process.
 
-<div class="note">See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.).</div><div class="note">The definitions of “[set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents)” and “[set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs)” in the Key Terms section if the Introduction are predicated on the ability to navigate from each element of the set to each other, and navigation is a type of locating. So the mechanism used to navigate between elements of the set will be one way of locating information in the set. Non-web environments, generally major operating systems with browse and search capabilities, often provide infrastructure and tools that provide mechanisms for locating content in a set of non-web documents or a set of software programs. For example, it may be possible to browse through the files or programs that make up a set, or search within members of the set for the names of other members. A file directory would be the equivalent of a site map for documents in a set, and a search function in a file system would be equivalent to a web search function for web pages. Such facilities may provide additional ways of locating information in the set.</div><div class="note">An example of the use of “a software program that is part of process”, that would meet the exception for this Success Criterion, would be one where programs are interlinked but the interlinking depends on program A being used before program B, for validation or to initialize the dataset etc.</div><div class="note">While some users may find it useful to have multiple ways to locate some groups of user interface elements within a document or software program, this is not required by the success criterion (and may pose difficulties in some situations).</div><div class="note">The definitions of “[set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_-documents)” and “[set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs)” in WCAG2ICT require every item in the set to be independently reachable, and so nothing in such a set can be a “step in a process” that can't be reached any other way. The purpose of the exception—that items in a process are exempt from meeting this success criterion—is achieved by the definition of set.</div>
+<div class="note">
+    
+See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.).</div><div class="note">
+
+The definitions of “[set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents)” and “[set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs)” in the Key Terms section if the Introduction are predicated on the ability to navigate from each element of the set to each other, and navigation is a type of locating. So the mechanism used to navigate between elements of the set will be one way of locating information in the set. Non-web environments, generally major operating systems with browse and search capabilities, often provide infrastructure and tools that provide mechanisms for locating content in a set of non-web documents or a set of software programs. For example, it may be possible to browse through the files or programs that make up a set, or search within members of the set for the names of other members. A file directory would be the equivalent of a site map for documents in a set, and a search function in a file system would be equivalent to a web search function for web pages. Such facilities may provide additional ways of locating information in the set.</div>
+<div class="note">
+    
+An example of the use of “a software program that is part of process”, that would meet the exception for this Success Criterion, would be one where programs are interlinked but the interlinking depends on program A being used before program B, for validation or to initialize the dataset etc.</div>
+<div class="note">
+    
+While some users may find it useful to have multiple ways to locate some groups of user interface elements within a document or software program, this is not required by the success criterion (and may pose difficulties in some situations).</div>
+<div class="note">
+    
+The definitions of “[set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_-documents)” and “[set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs)” in WCAG2ICT require every item in the set to be independently reachable, and so nothing in such a set can be a “step in a process” that can't be reached any other way. The purpose of the exception—that items in a process are exempt from meeting this success criterion—is achieved by the definition of set.</div>
 
 ##### headings-and-labels
 
@@ -365,7 +466,9 @@ With these substitutions, this success criterion would read:
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.4.6](http://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels#intent) (also provided below).
 
-<div class="note">In [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software), headings and labels are used to describe sections of [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) and controls respectively. In some cases it may be unclear whether a piece of static text is a heading or a label. But whether treated as a label or a heading, the requirement is the same: that if they are present they describe the topic or purpose of the item(s) they are associated with.</div>
+<div class="note">
+    
+In [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software), headings and labels are used to describe sections of [content](http://w3c.github.io/wcag2ict/#wcag2ict-def_content) and controls respectively. In some cases it may be unclear whether a piece of static text is a heading or a label. But whether treated as a label or a heading, the requirement is the same: that if they are present they describe the topic or purpose of the item(s) they are associated with.</div>
 
 ##### focus-visible
 
@@ -428,7 +531,12 @@ With these substitutions, it would read:
 
 **3.1.1 Language of Page:** The default [human language](#dfn-human-language) of <INS>[non-web documents](#dfn-non-web-documents) or [software](#dfn-software)</INS> can be [programmatically determined](#dfn-programmatically-determined). (Level A)
 
-<div class="note">Where software platforms provide a “locale / language” setting, applications that use that setting and render their interface in that “locale / language” would comply with this success criterion. Applications that do not use the platform “locale / language” setting but instead use an [accessibility-supported](http://w3c.github.io/wcag2ict/#wcag2ict-def_accessibility-supported) method for exposing the human language of the [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) would also comply with this success criterion. Applications implemented in technologies where [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at) cannot determine the human language and that do not support the platform “locale / language” setting may not be able to meet this success criterion in that locale / language.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+Where software platforms provide a “locale / language” setting, applications that use that setting and render their interface in that “locale / language” would comply with this success criterion. Applications that do not use the platform “locale / language” setting but instead use an [accessibility-supported](http://w3c.github.io/wcag2ict/#wcag2ict-def_accessibility-supported) method for exposing the human language of the [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) would also comply with this success criterion. Applications implemented in technologies where [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at) cannot determine the human language and that do not support the platform “locale / language” setting may not be able to meet this success criterion in that locale / language.</div>
+<div class="note">
+    
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### language-of-parts
 
@@ -440,7 +548,12 @@ With these substitutions, it would read:
 
 **3.1.2 Language of Parts:** The [human language](#dfn-human-language) of each passage or phrase in the <INS>[non-web document](#dfn-non-web-document) or [software](#dfn-software)</INS> can be [programmatically determined](#dfn-programmatically-determined) except for proper names, technical terms, words of indeterminate language, and words or phrases that have become part of the vernacular of the immediately surrounding text. (Level AA)
 
-<div class="note">There are some [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) and [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) technologies where there is no assistive technology supported method for marking the language for the different passages or phrases in the [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) or software, and it would not be possible to meet this success criterion with those technologies.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+There are some [software](http://w3c.github.io/wcag2ict/#wcag2ict-def_software) and [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) technologies where there is no assistive technology supported method for marking the language for the different passages or phrases in the [non-web document](http://w3c.github.io/wcag2ict/#wcag2ict-def_document) or software, and it would not be possible to meet this success criterion with those technologies.</div>
+<div class="note">
+    
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 #### predictable
 
@@ -458,7 +571,9 @@ Guideline 3.2 Predictable: Make <INS>[non-web documents](#dfn-non-web-documents)
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.2.1](http://www.w3.org/WAI/WCAG22/Understanding/on-focus#intent) (also provided below).
 
-<div class="note">Some compound documents and their user agents are designed to provide significantly different viewing and editing functionality depending upon what portion of the compound document is being interacted with (e.g. a presentation that contains an embedded spreadsheet, where the menus and toolbars of the user agent change depending upon whether the user is interacting with the presentation content, or the embedded spreadsheet content). If the user uses a mechanism other than putting focus on that portion of the compound document with which they mean to interact (e.g. by a menu choice or special keyboard gesture), any resulting [change of context](#dfn-change-of-context) wouldn't be subject to this success criterion because it was not caused by a change of focus.</div>
+<div class="note">
+    
+Some compound documents and their user agents are designed to provide significantly different viewing and editing functionality depending upon what portion of the compound document is being interacted with (e.g. a presentation that contains an embedded spreadsheet, where the menus and toolbars of the user agent change depending upon whether the user is interacting with the presentation content, or the embedded spreadsheet content). If the user uses a mechanism other than putting focus on that portion of the compound document with which they mean to interact (e.g. by a menu choice or special keyboard gesture), any resulting [change of context](#dfn-change-of-context) wouldn't be subject to this success criterion because it was not caused by a change of focus.</div>
 
 ##### on-input
 
@@ -482,7 +597,12 @@ With these substitutions, this success criterion would read:
 
 **3.2.3 Consistent Navigation:** Navigational mechanisms that are repeated on multiple <INS>[software programs](#dfn-software-programs)</INS> within a [set of <INS>software programs</INS>](#dfn-set-of-software-programs) occur in the same relative order each time they are repeated, unless a change is initiated by the user.
 
-<div class="note">See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software programs is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div><div class="note">Although not required by this success criterion, ensuring that navigation elements have consistent order when repeated _within_ non-web documents or software programs directly addresses user needs identified in the Intent section for this Success Criterion, and is generally considered best practice.</div>
+<div class="note">
+    
+See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software programs is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div>
+<div class="note">
+    
+Although not required by this success criterion, ensuring that navigation elements have consistent order when repeated _within_ non-web documents or software programs directly addresses user needs identified in the Intent section for this Success Criterion, and is generally considered best practice.</div>
 
 ##### consistent-identification
 
@@ -500,7 +620,12 @@ With these substitutions, this success criterion would read:
 
 **3.2.4 Consistent Identification:** Components that have the [same functionality](#dfn-same-functionality) within a [set of <INS>software programs</INS>](#dfn-set-of-software-programs) are identified consistently.
 
-<div class="note">See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software programs is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div><div class="note">Although not required by this success criterion, ensuring that component identification be consistent when they occur more than once _within_ non-web documents or software programs directly addresses user needs identified in the Intent section for this Success Criterion, and is generally considered best practice.</div>
+<div class="note">
+    
+See [set of documents](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-documents) and [set of software programs](http://w3c.github.io/wcag2ict/#wcag2ict-def_set-of-software-programs) in the Key Terms section of the Introduction to determine when a group of documents or software programs is considered a set for this success criterion. (Sets of software that meet this definition appear to be extremely rare.)</div>
+<div class="note">
+    
+Although not required by this success criterion, ensuring that component identification be consistent when they occur more than once _within_ non-web documents or software programs directly addresses user needs identified in the Intent section for this Success Criterion, and is generally considered best practice.</div>
 
 ##### consistent-help
 <p class="ednote">This section is to be developed by the WCAG2ICT Task Force.</p>
@@ -583,13 +708,20 @@ With these substitutions, it would read:
 
 **4.1.1 Parsing:** <INS>For [non-web documents](#dfn-non-web-documents) or [software](#dfn-software) that use markup languages, in such a way that the markup is separately exposed and available to [assistive technologies](#dfn-assistive-technologies) and accessibility features of software or to a user-selectable [user agent](#dfn-user-agent)</INS>, elements have complete start and end tags, elements are nested according to their specifications, elements do not contain duplicate attributes, and any IDs are unique, except where the specifications allow these features. (Level A)
 
-<div class="note">Start and end tags that are missing a critical character in their formation, such as a closing angle bracket or a mismatched attribute value quotation mark are not complete.</div><div class="note">Markup is not always available to [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at) or to user selectable [user agents](http://w3c.github.io/wcag2ict/#wcag2ict-def_useragent) such as browsers. Software sometimes uses markup languages internally for persistence of the software user interface, in ways where the markup is never available to assistive technology (either directly or through a document object model (DOM)), or to a user agent (such as a browser). In such cases, conformance to this provision would have no impact on accessibility as it can have for web content where it is exposed.</div>
+<div class="note">
+    
+Start and end tags that are missing a critical character in their formation, such as a closing angle bracket or a mismatched attribute value quotation mark are not complete.</div>
+<div class="note">
+    
+Markup is not always available to [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at) or to user selectable [user agents](http://w3c.github.io/wcag2ict/#wcag2ict-def_useragent) such as browsers. Software sometimes uses markup languages internally for persistence of the software user interface, in ways where the markup is never available to assistive technology (either directly or through a document object model (DOM)), or to a user agent (such as a browser). In such cases, conformance to this provision would have no impact on accessibility as it can have for web content where it is exposed.</div>
 
 Examples of markup that is separately exposed and available to [assistive technologies](http://w3c.github.io/wcag2ict/#wcag2ict-def_at) and to [user agents](http://w3c.github.io/wcag2ict/#wcag2ict-def_useragent) include: documents encoded in HTML, ODF, and OOXML. In these examples, the markup can be parsed entirely in two ways: (a) by assistive technologies which may directly open the document, (b) by assistive technologies using DOM APIs of user agents for these document formats.
 
 Examples of markup used internally for persistence of the software user interface that are never exposed to [assistive technology](http://w3c.github.io/wcag2ict/#wcag2ict-def_at) include but are not limited to: XUL, GladeXML, and FXML. In these examples assistive technology only interacts with the user interface of generated software.
 
-<div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### name-role-value
 
@@ -601,7 +733,18 @@ With this substitution, it would read:
 
 **4.1.2 Name, Role, Value:** For all [user interface components](#dfn-user-interface-components) (including but not limited to: form elements, links and components generated by scripts), the [name](#dfn-name) and [role](#dfn-role) can be [programmatically determined](#dfn-programmatically-determined); states, properties, and values that can be set by the user can be [programmatically set](#dfn-programmatically-set); and notification of changes to these items is available to [user agents](#dfn-user-agents), including [assistive technologies](#dfn-assistive-technologies). (Level A)
 
-<div class="note"><INS>This success criterion is primarily for software developers who develop or use custom user interface components. Standard user interface components on most [accessibility-supported](#dfn-accessibility-supported) platforms already meet this success criterion when used according to specification.</INS></div><div class="note">For conforming to this success criterion, it is usually best practice for software user interfaces to use the accessibility services provided by platform software. These accessibility services enable interoperability between software user interfaces and both assistive technologies and accessibility features of software in standardized ways. Most platform accessibility services go beyond programmatic exposure of name and role, and programmatic setting of states, properties and values (and notification of same), and specify additional information that could or should be exposed and / or set (for instance, a list of the available actions for a given user interface component, and a means to programmatically execute one of the listed actions).</div><div class="note">For document formats that support interoperability with assistive technology, standard user interface components often meet this success criterion when used according to the general design and accessibility guidance for the document format.</div><div class="note">See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
+<div class="note">
+    
+<INS>This success criterion is primarily for software developers who develop or use custom user interface components. Standard user interface components on most [accessibility-supported](#dfn-accessibility-supported) platforms already meet this success criterion when used according to specification.</INS></div>
+<div class="note">
+    
+For conforming to this success criterion, it is usually best practice for software user interfaces to use the accessibility services provided by platform software. These accessibility services enable interoperability between software user interfaces and both assistive technologies and accessibility features of software in standardized ways. Most platform accessibility services go beyond programmatic exposure of name and role, and programmatic setting of states, properties and values (and notification of same), and specify additional information that could or should be exposed and / or set (for instance, a list of the available actions for a given user interface component, and a means to programmatically execute one of the listed actions).</div>
+<div class="note">
+
+For document formats that support interoperability with assistive technology, standard user interface components often meet this success criterion when used according to the general design and accessibility guidance for the document format.</div>
+<div class="note">
+    
+See also the discussion on [Closed Functionality](http://w3c.github.io/wcag2ict/#closed-functionality).</div>
 
 ##### status-messages
 <p class="ednote">This section is to be developed by the WCAG2ICT Task Force.</p>


### PR DESCRIPTION
Needed to add in a blank line between the beginning of a class="note" div and the content within the div to allow markup to be correctly parsed and rendered.