### PR TITLE
No smaller text and no underline for `ins` elements

### DIFF
--- a/respec-config.js
+++ b/respec-config.js
@@ -2,7 +2,7 @@ var respecConfig = {
 	noRecTrack: true,
 	tocIntroductory: true,
 	specStatus: "ED",
-	
+	maxTocLevel: 3,
 	shortName: "wcag2ict",
 	
 	//publishDate:  "",

--- a/wcag2ict.css
+++ b/wcag2ict.css
@@ -1,7 +1,3 @@
-.wcag-quote 
-{
-  font-size: smaller;
-}
 .wcag-quote .note, .wcag-quote .ednote, .wcag-quote .example 
 {
   font-style: italic;

--- a/wcag2ict.css
+++ b/wcag2ict.css
@@ -1,6 +1,11 @@
-.wcag-quote .note, .wcag-quote .ednote, .wcag-quote .example 
-{
+.wcag-quote .note,
+.wcag-quote .ednote,
+.wcag-quote .example {
   font-style: italic;
   background-color: #EEE;
   border-left-style: none;
+}
+
+ins {
+  text-decoration: none;
 }


### PR DESCRIPTION
Removes CSS that created smaller text for SC quotes