### PR TITLE
Changes to 7.3.1.1 to remove all redundant links

### DIFF
--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -94,27 +94,27 @@ With these substitutions and addition, it would read:
 
 supported by users' [assistive technologies](#dfn-assistive-technologies) as well as the accessibility features in <INS>**[[user agents](#dfn-user-agents) or other [software](#dfn-software)]**</INS>
 
-To qualify as an accessibility-supported use of a <INS>**[[non-web document](#dfn-non-web-document) or [software](#dfn-software)]**</INS> [technology](#dfn-technologies) (or feature of a technology), both 1 and 2 must be satisfied for a <INS>**[[non-web document](#dfn-non-web-document) or [software](#dfn-software)]**</INS> [technology](#dfn-technologies) (or feature):
+To qualify as an accessibility-supported use of a <INS>**[[non-web document](#dfn-non-web-document) or software]**</INS> [technology](#dfn-technologies) (or feature of a technology), both 1 and 2 must be satisfied for a <INS>**[non-web document or software]**</INS> technology (or feature):
 
-1.  **The way that the <INS>[[non-web document](#dfn-non-web-document) or [software](#dfn-software) [technology](#dfn-technologies)]</INS> is used must be supported by users' assistive technology (AT).** This means that the way that the technology is used has been tested for interoperability with users' assistive technology in the [human language(s)](#dfn-human-language) of the [content](#dfn-content),
+1.  **The way that the <INS>**[non-web document or software technology]**</INS> is used must be supported by users' assistive technology (AT).** This means that the way that the technology is used has been tested for interoperability with users' assistive technology in the [human language(s)](#dfn-human-language) of the [content](#dfn-content),
     
     **AND**
     
-2.  **The <INS>[[non-web document](#dfn-non-web-document) or [software](#dfn-software)]</INS> [technology](#dfn-technologies) must have accessibility-supported user agents <INS>[or other [software](#dfn-software)]</INS> that are available to users.** This means that at least one of the following four statements is true:
+2.  **The <INS>**[non-web document or software]**</INS> technology must have accessibility-supported user agents <INS>**[or other software]**</INS> that are available to users.** This means that at least one of the following four statements is true:
     
-    1.  The [technology](#dfn-technologies) is supported natively in widely-distributed user agents <INS>**[or other [software](#dfn-software)]**</INS> that are also accessibility supported (such as HTML and CSS);
+    1.  The technology is supported natively in widely-distributed user agents <INS>**[or other software]**</INS> that are also accessibility supported (such as HTML and CSS);
         
         **OR**
         
-    2.  The [technology](#dfn-technologies) is supported in a widely-distributed plug-in <INS>**[or other software extension]**</INS> that is also accessibility supported;
+    2.  The technology is supported in a widely-distributed plug-in <INS>**[or other software extension]**</INS> that is also accessibility supported;
         
         **OR**
         
-    3.  The [content](#dfn-content) is available in a closed environment, such as a university or corporate network, where the user agent <INS>**[or other [software](#dfn-software)]**</INS> required by the technology and used by the organization is also accessibility supported;
+    3.  The content is available in a closed environment, such as a university or corporate network, where the user agent <INS>**[or other software]**</INS> required by the technology and used by the organization is also accessibility supported;
         
         **OR**
         
-    4.  The user agent(s) that support the [technology](#dfn-technologies) are accessibility supported and are available for download or purchase in a way that:
+    4.  The user agent(s) that support the technology are accessibility supported and are available for download or purchase in a way that:
         
         *   does not cost a person with a disability any more than a person without a disability **and**
             


### PR DESCRIPTION
As per bullet in issue #147 
"1. For 7.3.1.1, remove all redundant term links from the definition of accessibility supported in WCAG2ICT document to look more similar to accessibility supported in WCAG 2.2. Only the first occurrence of the desired linked term should appear for each definition."