### PR TITLE
Further updates to 7.3.1.1 to fix broken links

### DIFF
--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -92,11 +92,11 @@ With these substitutions and addition, it would read:
 
 <DL><DT>accessibility supported</DT><DD>
 
-supported by users' [assistive technologies](#dfn-assistive-technologies) as well as the accessibility features in <INS>**[[user agents](#dfn-user-agents) or other [software](#dfn-software)]**</INS>
+supported by users' [assistive technologies](#dfn-assistive-technology) as well as the accessibility features in <INS>**[[user agents](#dfn-user-agent) or other [software](#software)]**</INS>
 
-To qualify as an accessibility-supported use of a <INS>**[[non-web document](#dfn-non-web-document) or [software](#dfn-software)]**</INS> [technology](#dfn-technologies) (or feature of a technology), both 1 and 2 must be satisfied for a <INS>**[[non-web document](#dfn-non-web-document) or [software](#dfn-software)]**</INS> [technology](#dfn-technologies) (or feature):
+To qualify as an accessibility-supported use of a <INS>**[[non-web document](#document) or software]**</INS> [technology](#dfn-technologies) (or feature of a technology), both 1 and 2 must be satisfied for a <INS>**[[non-web document](#dfn-non-web-document) or [software](#dfn-software)]**</INS> [technology](#dfn-technologies) (or feature):
 
-1.  **The way that the <INS>[[non-web document](#dfn-non-web-document) or [software](#dfn-software) [technology](#dfn-technologies)]</INS> is used must be supported by users' assistive technology (AT).** This means that the way that the technology is used has been tested for interoperability with users' assistive technology in the [human language(s)](#dfn-human-language) of the [content](#dfn-content),
+1.  **The way that the <INS>[[non-web document](#dfn-non-web-document) or [software](#dfn-software) [technology](#dfn-technology)]</INS> is used must be supported by users' assistive technology (AT).** This means that the way that the technology is used has been tested for interoperability with users' assistive technology in the [human language(s)](https://www.w3.org/TR/WCAG22/#dfn-human-language-s) of the [content](#dfn-content),
     
     **AND**
     

--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -94,27 +94,27 @@ With these substitutions and addition, it would read:
 
 supported by users' [assistive technologies](#dfn-assistive-technology) as well as the accessibility features in <INS>**[[user agents](#dfn-user-agent) or other [software](#software)]**</INS>
 
-To qualify as an accessibility-supported use of a <INS>**[[non-web document](#document) or software]**</INS> [technology](#dfn-technologies) (or feature of a technology), both 1 and 2 must be satisfied for a <INS>**[[non-web document](#dfn-non-web-document) or [software](#dfn-software)]**</INS> [technology](#dfn-technologies) (or feature):
+To qualify as an accessibility-supported use of a <INS>**[[non-web document](#document) or software]**</INS> [technology](#dfn-technologies) (or feature of a technology), both 1 and 2 must be satisfied for a <INS>**[non-web document or software]**</INS> technology (or feature):
 
-1.  **The way that the <INS>[[non-web document](#dfn-non-web-document) or [software](#dfn-software) [technology](#dfn-technology)]</INS> is used must be supported by users' assistive technology (AT).** This means that the way that the technology is used has been tested for interoperability with users' assistive technology in the [human language(s)](https://www.w3.org/TR/WCAG22/#dfn-human-language-s) of the [content](#dfn-content),
+1.  **The way that the <INS>[non-web document or software technology]</INS> is used must be supported by users' assistive technology (AT).** This means that the way that the technology is used has been tested for interoperability with users' assistive technology in the [human language(s)](https://www.w3.org/TR/WCAG22/#dfn-human-language-s) of the [content](#dfn-content),
     
     **AND**
     
-2.  **The <INS>[[non-web document](#dfn-non-web-document) or [software](#dfn-software)]</INS> [technology](#dfn-technologies) must have accessibility-supported user agents <INS>[or other [software](#dfn-software)]</INS> that are available to users.** This means that at least one of the following four statements is true:
+2.  **The <INS>[non-web document or software</INS> technology must have accessibility-supported user agents <INS>[or other software]</INS> that are available to users.** This means that at least one of the following four statements is true:
     
-    1.  The [technology](#dfn-technologies) is supported natively in widely-distributed user agents <INS>**[or other [software](#dfn-software)]**</INS> that are also accessibility supported (such as HTML and CSS);
+    1.  The technology is supported natively in widely-distributed user agents <INS>**[or other software]**</INS> that are also accessibility supported (such as HTML and CSS);
         
         **OR**
         
-    2.  The [technology](#dfn-technologies) is supported in a widely-distributed plug-in <INS>**[or other software extension]**</INS> that is also accessibility supported;
+    2.  The technology is supported in a widely-distributed plug-in <INS>**[or other software extension]**</INS> that is also accessibility supported;
         
         **OR**
         
-    3.  The [content](#dfn-content) is available in a closed environment, such as a university or corporate network, where the user agent <INS>**[or other [software](#dfn-software)]**</INS> required by the technology and used by the organization is also accessibility supported;
+    3.  The content is available in a closed environment, such as a university or corporate network, where the user agent <INS>**[or other software]**</INS> required by the technology and used by the organization is also accessibility supported;
         
         **OR**
         
-    4.  The user agent(s) that support the [technology](#dfn-technologies) are accessibility supported and are available for download or purchase in a way that:
+    4.  The user agent(s) that support the technology are accessibility supported and are available for download or purchase in a way that:
         
         *   does not cost a person with a disability any more than a person without a disability **and**
             

--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -100,7 +100,7 @@ To qualify as an accessibility-supported use of a <INS>**[[non-web document](#do
     
     **AND**
     
-2.  **The <INS>[non-web document or software</INS> technology must have accessibility-supported user agents <INS>[or other software]</INS> that are available to users.** This means that at least one of the following four statements is true:
+2.  **The <INS>[non-web document or software]</INS> technology must have accessibility-supported user agents <INS>[or other software]</INS> that are available to users.** This means that at least one of the following four statements is true:
     
     1.  The technology is supported natively in widely-distributed user agents <INS>**[or other software]**</INS> that are also accessibility supported (such as HTML and CSS);
         

--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -94,7 +94,7 @@ With these substitutions and addition, it would read:
 
 supported by users' [assistive technologies](#dfn-assistive-technology) as well as the accessibility features in <INS>**[[user agents](#dfn-user-agent) or other [software](#software)]**</INS>
 
-To qualify as an accessibility-supported use of a <INS>**[[non-web document](#document) or software]**</INS> [technology](#dfn-technologies) (or feature of a technology), both 1 and 2 must be satisfied for a <INS>**[non-web document or software]**</INS> technology (or feature):
+To qualify as an accessibility-supported use of a <INS>**[[non-web document](#document) or software]**</INS> [technology](#dfn-technology) (or feature of a technology), both 1 and 2 must be satisfied for a <INS>**[non-web document or software]**</INS> technology (or feature):
 
 1.  **The way that the <INS>[non-web document or software technology]</INS> is used must be supported by users' assistive technology (AT).** This means that the way that the technology is used has been tested for interoperability with users' assistive technology in the [human language(s)](https://www.w3.org/TR/WCAG22/#dfn-human-language-s) of the [content](#dfn-content),
     


### PR DESCRIPTION
As per following bullets in issue #147 

2. In 7.3.1.1 Guidance When Applying “accessibility supported” to Non-Web Documents and Software. Link "assistive technologies" again looks OK (uses document anchor) but doesn't work in netlify version - it just opens the document at the start. https://deploy-preview-144--wcag2ict.netlify.app/#dfn-assistive-technologies MJM: change link reference to #dfn-assistive-technology
 3. In 7.3.1.1 accessibility supported list. Link "user agents" doesn't work https://deploy-preview-144--wcag2ict.netlify.app/#dfn-user-agents. MJM: change link reference to #user-agent
 4. In 7.3.1.1 Link "software" doesn't work https://deploy-preview-144--wcag2ict.netlify.app/#dfn-software MJM: change anchor to #software
 5. In 7.3.1.1 Link "non-web document" doesn't work https://deploy-preview-144--wcag2ict.netlify.app/#dfn-non-web-document in "1. The way that the [non-web document " MJM: change link reference to #document
 6. Link "software" doesn't work https://deploy-preview-144--wcag2ict.netlify.app/#dfn-software in "1. The way that the [non-web document "… MJM: I think this isn't the first link to the definition of software or non-web document, remove them. Only one link per definition is needed.
 7. Link "technology" doesn't work https://deploy-preview-144--wcag2ict.netlify.app/#dfn-technologies in same section MJM: change link reference to #dfn-technology
 8. Link "human language(s)" doesn't work https://deploy-preview-144--wcag2ict.netlify.app/#dfn-human-language in same section MJM: should link to full URL https://www.w3.org/TR/WCAG22/#dfn-human-language-s
 9. Link "content" in the same section works as expected https://deploy-preview-144--wcag2ict.netlify.app/#dfn-content MJM: If this is the first link to the definition of content for the term "accessibility-supported" change the link to #content
 10. Again, in bullet 2. The [non-web document or software] … Links are broken for non-web document, software, technology, software MJM: Remove these links. Links to these same terms already appear in the "accessibility-supported" definition - only need one.
 11. Bullet 2.2. The technology is supported in a widely-distributed plug-in [or other software extension]. No link for other software extension - not sure if this is correct or not. MJM: Remove the link. A link to "technology" already appears in the "accessibility-supported" definition - only need one.