### PR TITLE
Update README.md to point to github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 
 # WCAG2ICT
 
-This is the repository for [WCAG2ICT Task Force](https://www.w3.org/WAI/GL/task-forces/wcag2ict/). This is the latest [editor's draft](https://wcag2ict.netlify.app/).
+This is the repository for [WCAG2ICT Task Force](https://www.w3.org/WAI/GL/task-forces/wcag2ict/). This is the latest [editor's draft](https://w3c.github.io/wcag2ict/).

--- a/respec-config.js
+++ b/respec-config.js
@@ -14,7 +14,7 @@ var respecConfig = {
 	prevRecURI: "https://www.w3.org/TR/wcag2ict/",
 	
 	// if there a publicly available Editors Draft, this is the link
-	edDraftURI: "https://wcag2ict.netlify.app/",
+	edDraftURI: "https://w3c.github.io/wcag2ict/",
 	
 	editors: [
 		{


### PR DESCRIPTION
Now that the scripting is fixed, we can move the links back to the github.io URL