### PR TITLE
Try removing "Guidance when" sections for definitions from TOC

### DIFF
--- a/wcag2ict.js
+++ b/wcag2ict.js
@@ -237,7 +237,7 @@ function hideDeepNums() {
 function hideDeepNumsGlossary() {
 	document.querySelectorAll("#glossary-items-with-specific-guidance").forEach(function(item) {
 		var id = item.id;
-		if (id.startsWith("guidance-when-")) {
+		if (id.startsWith("glossary-items-with-")) {
 			var tocItem = getTocItem(id);
 			if (tocItem != null) tocItem.remove();
 			var secno = item.querySelector("bdi.secno");

--- a/wcag2ict.js
+++ b/wcag2ict.js
@@ -234,8 +234,21 @@ function hideDeepNums() {
 	});
 }
 
+function hideDeepNumsGlossary() {
+	document.querySelectorAll("#glossary-items-with-specific-guidance").forEach(function(item) {
+		var id = item.id;
+		if (id.startsWith("guidance-when-")) {
+			var tocItem = getTocItem(id);
+			if (tocItem != null) tocItem.remove();
+			var secno = item.querySelector("bdi.secno");
+			if (secno != null) secno.remove();
+		}
+	});
+}
+
 function finalCleanup() {
 	hideDeepNums();
+	hideDeepNumsGlossary();
 	numberNotes();
 	renumberExamples();
 }


### PR DESCRIPTION
As part of cleaning up the document formatting, I would like to remove the "Guidance when applying" sections from the term definitions sub-sections. This will also help to reduce the size of the TOC and make it more similar to the 2013 WCAG2ICT.