### PR TITLE
Remove "Example:" text from anything marked with a class of example

### DIFF
--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -141,7 +141,7 @@ the purpose cannot be determined from the link and all information of the <INS>*
 
 <div class="example">
 
-**Example:** The word guava in the following sentence “One of the notable exports is guava” is a link. The link could lead to a definition of guava, a chart listing the quantity of guava exported or a photograph of people harvesting guava. Until the link is activated, all readers are unsure and the person with a disability is not at any disadvantage.</div>
+The word guava in the following sentence “One of the notable exports is guava” is a link. The link could lead to a definition of guava, a chart listing the quantity of guava exported or a photograph of people harvesting guava. Until the link is activated, all readers are unsure and the person with a disability is not at any disadvantage.</div>
 </DD></DL>
 
 #### dfn-assistive-technology
@@ -167,7 +167,7 @@ Assistive technologies often communicate data and messages with <INS>**[mainstre
 The distinction between <INS>**[mainstream ICTs]**</INS> and assistive technologies is not absolute. Many <INS>**[mainstream ICTs]**</INS> provide some features to assist individuals with disabilities. The basic difference is that <INS>**[mainstream ICTs]**</INS> target broad and diverse audiences that usually include people with and without disabilities. Assistive technologies target narrowly defined populations of users with specific disabilities. The assistance provided by an assistive technology is more specific and appropriate to the needs of its target users. The <INS>**[mainstream ICT]**</INS> may provide important functionality to assistive technologies like retrieving <INS>**[[content](#content-on-and-off-the-web)]**</INS> from program objects or parsing markup into identifiable bundles.</div>
 <div class="example">
 
-**Example:** Assistive technologies that are important in the context of this document include the following:
+Assistive technologies that are important in the context of this document include the following:
 
 - screen magnifiers, and other visual reading assistants, which are used by people with visual, perceptual and physical print disabilities to change text font, size, spacing, color, synchronization with speech, etc. in order to improve the visual readability of rendered text and images;    
 - screen readers, which are used by people who are blind to read textual information through synthesized speech or braille;
@@ -204,7 +204,7 @@ Changes in context include changes of:
 A change of content is not always a change of context. Changes in content, such as an expanding outline, dynamic menu, or a tab control do not necessarily change the context, unless they also change one of the above (e.g., focus).</div>
 <div class="example">
 
-**Example:** Opening a new window, moving focus to a different component, going to a new page (including anything that would look to a user as if they had moved to a new page) or significantly re-arranging the content of a page are examples of changes of context.</div>
+Opening a new window, moving focus to a different component, going to a new page (including anything that would look to a user as if they had moved to a new page) or significantly re-arranging the content of a page are examples of changes of context.</div>
 </DD></DL>
 <div class="note">
 
@@ -384,10 +384,10 @@ determined by [software](#software) from author-supplied data provided in a way 
 
 <div class="example">
 
-**Example 1:** Determined in a markup language from elements and attributes that are accessed directly by commonly available assistive technology <INS>**[and accessibility features of software]**</INS>.</div>
+Determined in a markup language from elements and attributes that are accessed directly by commonly available assistive technology <INS>**[and accessibility features of software]**</INS>.</div>
 <div class="example">
 
-**Example 2:** Determined from technology-specific data structures in a non-markup language and exposed to assistive technology <INS>**[and accessibility features of software]**</INS> via an accessibility API that is supported by commonly available assistive technology <INS>**[and accessibility features of software]**</INS>.</div>
+Determined from technology-specific data structures in a non-markup language and exposed to assistive technology <INS>**[and accessibility features of software]**</INS> via an accessibility API that is supported by commonly available assistive technology <INS>**[and accessibility features of software]**</INS>.</div>
 </DD></DL>
 <div class="note">
 
@@ -465,7 +465,7 @@ text or number by which software can identify the function of a component within
 
 <div class="example">
 
-**Example:** A number that indicates whether an image functions as a hyperlink, command button, or check box.</div>
+A number that indicates whether an image functions as a hyperlink, command button, or check box.</div>
 </DD></DL>
 <div class="note">
 
@@ -483,14 +483,12 @@ With these substitutions, it would read:
 
 same result when used
 
-<div class="example">
-
-**Example <INS>\[1\]</INS>:** 
+<div class="example"> 
 
 A submit “search” button on one web page and a “find” button on another web page may both have a field to enter a term and list topics in the Web site related to the term submitted. In this case, they would have the same functionality but would not be labeled consistently.</div>
 <div class="example">
 
-<INS>**[Example 2: A ribbon icon that saves the document that looks like an arrow pointing into a folder in one case, and an arrow pointing into a hard drive in another. In this case as well, they would have the same functionality but would not be labeled consistently.]**</INS></div></DD></DL>
+A ribbon icon that saves the document that looks like an arrow pointing into a folder in one case, and an arrow pointing into a hard drive in another. In this case as well, they would have the same functionality but would not be labeled consistently.</div></DD></DL>
 
 #### dfn-satisfies-a-success-criterion
 
@@ -579,7 +577,7 @@ With these substitutions, it would read:
 
 <div class="example">
 
-**Example:** Some common examples of <INS>**[non-web document and software technologies include ODF, OOXML, Java, and C++]**</INS>.</div></DD></DL>
+Some common examples of <INS>**[non-web document and software technologies include ODF, OOXML, Java, and C++]**</INS>.</div></DD></DL>
 
 #### dfn-up-event
 
@@ -620,7 +618,7 @@ User interface components include form elements and links as well as components 
 What is meant by "component" or "user interface component" here is also sometimes called "user interface element".</div>
 <div class="example">
 
-**Example:** <INS>**[A [software](#software) program has 2 controls: a text field for entering a file name and a drop down list box for choosing a folder. Each is a user interface component with a name that is settable by the software.]**</INS></div>
+A [software](#software) program has 2 controls: a text field for entering a file name and a drop down list box for choosing a folder. Each is a user interface component with a name that is settable by the software.</div>
 </DD></DL>
 
 #### dfn-viewport

--- a/key-terms.md
+++ b/key-terms.md
@@ -61,9 +61,9 @@ A single document may be composed of multiple files such as the video content, c
 
 <div class="example">
 
-**Example:** An assembly of files that represented the video, audio, captions and timing files for a movie would be a document.
+An assembly of files that represented the video, audio, captions and timing files for a movie would be a document.
 
-**Counterexample:** A binder file used to bind together the various exhibits for a legal case would not be a document.</div>
+Counterexample: A binder file used to bind together the various exhibits for a legal case would not be a document.</div>
 
 ### Set of Documents
 
@@ -82,7 +82,7 @@ If a set is broken apart, the individual parts are no longer part of a set, and 
 
 <div class="example">
 
-**Example:** One example of a set of documents would be a three-part report where each part is a separate file. The table of contents is repeated at the beginning of each file to enable navigation to the other parts.</div>
+One example of a set of documents would be a three-part report where each part is a separate file. The table of contents is repeated at the beginning of each file to enable navigation to the other parts.</div>
 
 ### Set of Software Programs
 
@@ -118,9 +118,9 @@ If there is no independent method to launch the software programs (as is common 
 Although the term “software” is used throughout this document because this would apply to stand alone software programs as well as individual software components and the software components in software-hardware combinations, the concept of “set of software programs” would only apply (by definition) to programs that can be launched separately from each other. Therefore, for the provisions that use the phrase “set of” (success criteria 2.4.1, 2.4.5, 3.2.3, and 3.2.4), the phrase “set of software programs” is used.</div>
 <div class="example">
 
-**Example:** One example of a set of software programs would be a group of programs that can be launched and used separately but are distributed together and all have a menu that allows users to launch, or switch to, each of the other programs in the group.
+One example of a set of software programs would be a group of programs that can be launched and used separately but are distributed together and all have a menu that allows users to launch, or switch to, each of the other programs in the group.
 
-**Counterexamples:** Examples of things that are **not** sets of software programs:
+Counterexamples: Examples of things that are **not** sets of software programs:
 
 * A suite of programs for authoring different types of documents (text, spreadsheets, presentations, etc.) where the programs don't provide an explicit, consistent means to launch, or switch to, each of the other programs in the group.
 * An office package consisting of multiple programs that launches as a single program that provides multiple functionalities such as writing, spreadsheet, etc., but the only way to navigate between programs is to open a document in one of the programs.
@@ -156,7 +156,7 @@ WCAG 2.2 defines **user agent** as:
 </DD></DL>
 <div class="example">
 
->**Example:** Web browsers, media players, plug-ins, and other programs—including [assistive technologies](#dfn-assistive-technology)—that help in retrieving, rendering, and interacting with Web content.</div>
+>Web browsers, media players, plug-ins, and other programs—including [assistive technologies](#dfn-assistive-technology)—that help in retrieving, rendering, and interacting with Web content.</div>
 For non-web ICT, “user agent” needs to be viewed differently. In WCAG 2.2, the term “user agent” only refers to retrieval and display of web content. For non-web ICT, the term “user agent” refers to retrieval and display of separate content that is _not on the Web_, which WCAG2ICT refers to as a “document”. Within WCAG2ICT, the term “user agent” is used as follows:
 
 <DL><DT>user agent (as used in WCAG2ICT)</DT><DD>

--- a/status-of-this-document.md
+++ b/status-of-this-document.md
@@ -13,6 +13,5 @@ Currently there are known issues in the quoted content from WCAG and Understandi
 
 - Anchor links from the included WCAG content to sections that do not exist in the WCAG2ICT document don't work
 - The words "Note" and "Example" are missing from notes and examples of quoted WCAG passages
-- The left bar that is present for included WCAG guidelines and success criteria is not present for the included Intent sections from the Understanding document.
 
 The group is currently working on updates to the format, styling, and linking for these passages, and expects to refine these in a future draft.


### PR DESCRIPTION
Now that scripting adds this text, it is no longer needed in the markdown.
Also removed the listed formatting error in the SOTD for the format of the included Intent. It has been fixed so the callout is consistent with included SC content.