### PR TITLE
Add 2.4.11 Focus Not Obscured (Minimum)

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -604,7 +604,8 @@ This applies directly as written, and as described in [Intent from Understanding
 ##### focus-not-obscured-minimum
 
 ###### Applying Success Criterion 2.4.11 Focus not Obscured to Non-Web Documents and Software
-<p class="ednote">This section is to be developed by the WCAG2ICT Task Force.</p>
+
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.4.11](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum#intent) (also provided below).
 
 #### input-modalities
 

--- a/introduction.md
+++ b/introduction.md
@@ -81,6 +81,7 @@ The following changes and additions have been made to update the 2013 WCAG2ICT d
     * [Success Criterion 2.5.4 Motion Actuation](#motion-actuation)
     * [Success Criterion 4.1.3 Status Messages](#status-messages)
 * New WCAG 2.2 Success Criteria
+    * [Success Criterion 2.4.11 Focus Not Obscured (Minimum)](#focus-not-obscured-minimum)
     * [Success Criterion 2.5.8 Target Size (Minimum)](#target-size-minimum)
     * [Success Criterion 3.3.7 Redundant Entry](#redundant-entry)
 * New terms


### PR DESCRIPTION
As of 9 November, the WCAG2ICT reached [resolution to incorporate 2.4.11 as-is](https://www.w3.org/2023/11/09-wcag2ict-minutes.html#r04).