### PR TITLE
Change link to understanding to go to WCAG 2.2 version

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -995,7 +995,7 @@ See also the discussion on [Closed Functionality](#closed-functionality).</div>
 
 ###### Applying SC 4.1.3 Status Messages to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 4.1.3](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html#intent) (also provided below) replacing "In content implemented using markup languages" with "In content implemented using markup languages, or that supports status message notifications".
+This applies directly as written, and as described in [Intent from Understanding Success Criterion 4.1.3](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html#intent) (also provided below) replacing "In content implemented using markup languages" with "In content implemented using markup languages, or that supports status message notifications".
 
 With this substitution, it would read:
 In <INS>**[content implemented using markup languages, or that supports status message notifications]**</INS>, [status messages](https://www.w3.org/TR/WCAG22/#dfn-status-messages) can be [programmatically determined](#dfn-programmatically-determined) through [role](#dfn-role) or properties such that they can be presented to the user by [assistive technologies](#dfn-assistive-technology) without receiving focus.

--- a/key-terms.md
+++ b/key-terms.md
@@ -37,7 +37,7 @@ For non-web content it is necessary to view this a bit more broadly. Within WCAG
 
 <DL><DT>content (non-web content) (as used in WCAG2ICT)</DT><DD>
 
-information and sensory experience to be communicated to the user by means of <INS>**[[software](#software)]**</INS>, including code or markup that defines the content's [structure](#dfn-structure), [presentation](https://www.w3.org/TR/WCAG22/#dfn-presentation), and interactions
+information and sensory experience to be communicated to the user by means of **<INS>[[software](#software)]</INS>**, including code or markup that defines the content's [structure](#dfn-structure), [presentation](https://www.w3.org/TR/WCAG22/#dfn-presentation), and interactions
 </DD></DL>
 <div class="note">
 
@@ -97,7 +97,7 @@ The term **set of documents**, as used in WCAG2ICT, has the meaning below:
 
 <DL><DT>set of documents (non-web) (as used in WCAG2ICT)</DT><DD>
 
-collection of <INS>**[[documents](#document)]**</INS> that share a common purpose, are created by the same author, group or organization <INS>**[and that are published together, and the documents all refer to each other by name or link]**</INS>
+collection of **<INS>[[documents](#document)]</INS>** that share a common purpose, are created by the same author, group or organization **<INS>[and that are published together, and the documents all refer to each other by name or link]</INS>**
 </DD></DL>
 <div class="note">
 
@@ -116,7 +116,7 @@ The term **set of software programs**, as used in WCAG2ICT, has the meaning belo
 
 <DL><DT>set of software programs (as used in WCAG2ICT)</DT><DD>
 
-collection of <INS>**[[software](#software) programs]**</INS> that share a common purpose, are created by the same author, group or organization <INS>**[and that are distributed together and can be launched and used independently from each other, but are interlinked each with every other one such that users can navigate from one program to another via a consistent method that appears in each member of the set]**</INS>
+collection of **<INS>[[software](#software) programs]</INS>** that share a common purpose, are created by the same author, group or organization **<INS>[and that are distributed together and can be launched and used independently from each other, but are interlinked each with every other one such that users can navigate from one program to another via a consistent method that appears in each member of the set]</INS>**
 </DD></DL>
 <div class="note">
 
@@ -187,7 +187,7 @@ For non-web ICT, “user agent” needs to be viewed differently. In WCAG 2, the
 
 <DL><DT>user agent (as used in WCAG2ICT)</DT><DD>
 
-any [software](#software) that retrieves and presents <INS>**[documents]**</INS> for users
+any [software](#software) that retrieves and presents **<INS>[documents]</INS>** for users
 </DD></DL>
 <div class="note">
 

--- a/key-terms.md
+++ b/key-terms.md
@@ -20,7 +20,7 @@ These services are commonly provided in the form of accessibility APIs (applicat
 The term **closed functionality**, as used in WCAG2ICT, has the meaning below:
 
 <DL><DT>closed functionality (as used in WCAG2ICT)</DT><DD>
-functionality that prevents users from attaching, installing, or using [assistive technology](#dfn-assistive-technology)</DD></DL>
+functionality that prevents users from attaching, installing, or using [assistive technologies](#dfn-assistive-technology)</DD></DL>
 <div class="note">
   
 To support users with disabilities, products with closed functionality can instead provide built-in features that function as assistive technology.</div>

--- a/key-terms.md
+++ b/key-terms.md
@@ -20,7 +20,8 @@ These services are commonly provided in the form of accessibility APIs (applicat
 The term **closed functionality**, as used in WCAG2ICT, has the meaning below:
 
 <DL><DT>closed functionality (as used in WCAG2ICT)</DT><DD>
-functionality that prevents users from attaching, installing, or using [assistive technologies](#dfn-assistive-technology)</DD></DL>
+
+functionality that prevents users from attaching, installing, or using [assistive technology](#dfn-assistive-technology)</DD></DL>
 <div class="note">
   
 To support users with disabilities, products with closed functionality can instead provide built-in features that function as assistive technology.</div>

--- a/key-terms.md
+++ b/key-terms.md
@@ -97,7 +97,7 @@ The term **set of documents**, as used in WCAG2ICT, has the meaning below:
 
 <DL><DT>set of documents (non-web) (as used in WCAG2ICT)</DT><DD>
 
-collection of <INS>**[documents](#document)**</INS> that share a common purpose, are created by the same author, group or organization <INS>**[and that are published together, and the documents all refer to each other by name or link]**</INS>
+collection of <INS>**[[documents](#document)]**</INS> that share a common purpose, are created by the same author, group or organization <INS>**[and that are published together, and the documents all refer to each other by name or link]**</INS>
 </DD></DL>
 <div class="note">
 

--- a/key-terms.md
+++ b/key-terms.md
@@ -116,7 +116,7 @@ The term **set of software programs**, as used in WCAG2ICT, has the meaning belo
 
 <DL><DT>set of software programs (as used in WCAG2ICT)</DT><DD>
 
-collection of <INS>**[software](#software) programs]**</INS> that share a common purpose, are created by the same author, group or organization <INS>**[and that are distributed together and can be launched and used independently from each other, but are interlinked each with every other one such that users can navigate from one program to another via a consistent method that appears in each member of the set]**</INS>
+collection of <INS>**[[software](#software) programs]**</INS> that share a common purpose, are created by the same author, group or organization <INS>**[and that are distributed together and can be launched and used independently from each other, but are interlinked each with every other one such that users can navigate from one program to another via a consistent method that appears in each member of the set]**</INS>
 </DD></DL>
 <div class="note">
 


### PR DESCRIPTION
This fixes an incorrect link URL for Issue #294.

Plus I'm fixing a missing "[" in the key term definition for"set of software"