### PR TITLE
Fix typo Parsing is obsolete only in WCAG 2.2.

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -971,7 +971,7 @@ Guideline 4.1 Compatible: Maximize compatibility with current and future <INS>**
 **WCAG 2.2 Guidance:**
 <div class="note">
 
-WCAG 2 has made this success criterion obsolete and removed it as a requirement in the standard. Therefore, the interpretation of this success criterion for [non-web documents](#document) and [software](#software) has been removed.</div>
+WCAG 2.2 has made this success criterion obsolete and removed it as a requirement in the standard. Therefore, the interpretation of this success criterion for [non-web documents](#document) and [software](#software) has been removed.</div>
 
 **WCAG 2.0 and 2.1 Guidance:**
 


### PR DESCRIPTION
Due to a [comment](https://github.com/w3c/wcag2ict/issues/266#issuecomment-1886401634) in the AG WG review of 4.1.1 Parsing.