### PR TITLE
Update acknowledgements with latest AG WG participants reviewing the doc

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -29,6 +29,8 @@
 * Daniel Bjorge (Deque Systems, Inc.)
 * Alastair Campbell (Nomensa)
 * Laura Carlson (Invited Expert)
+* DJ Chase (Invited Expert)
+* Azlan Cuttilan (Invited Expert)
 * Jennifer Delisi (Invited Expert)
 * Wilco Fiers (Deque Systems, Inc.)
 * Detlev Fischer (Invited Expert)

--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -50,6 +50,7 @@
 * Poornima Badhan Subramanian (Invited Expert)
 * Ben Tillyer (Invited Expert)
 * Kevin White (W3C Staff)
+* Frankie Wolf (Level Access)
 
 ### Participants in the APA Working Group that Contributed
 Special thanks goes to members of the APA working group that contributed their expertise to updates in the Text / Command-line / Terminal Applications and Interfaces content. 


### PR DESCRIPTION
See issue #331. Updating the AG WG list with those who participated in the latest review of WCAG2ICT.