### PR TITLE
Editorial: definition of "down event"

### DIFF
--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -288,8 +288,6 @@ People with low vision often use devices at less than the standard viewing dista
 
 #### dfn-down-event
 
-From the [WCAG 2 definition for down-event](https://www.w3.org/TR/WCAG22/#dfn-down-event):
-
 ##### Applying “down-event” to Non-Web Documents and Software
 
 This applies directly as written and as described in the WCAG 2 glossary.


### PR DESCRIPTION
Deleted extraneous text: "From the WCAG 2 definition for down-event:"