### PR TITLE
1.4.10 Reflow: remove Note 2 edits which differed from WCAG

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -255,7 +255,7 @@ Except for parts of the content which require two-dimensional layout for usage o
 
 <div class="note">
 
-Examples of content which relies upon two-dimensional layout are some informative images (such as maps and diagrams), video, games, presentations, data tables (not individual cells), and interfaces where it is necessary to keep toolbars in view while manipulating content. It is acceptable to provide two-dimensional scrolling for such content.</div>
+Examples of content which requires two-dimensional layout are images required for understanding (such as maps and diagrams), video, games, presentations, data tables (not individual cells), and interfaces where it is necessary to keep toolbars in view while manipulating content. It is acceptable to provide two-dimensional scrolling for such parts of the content.</div>
 
 <div class="note">
 


### PR DESCRIPTION
It looks like the Task Force accidentally edited 1.4.10 Note 2, which should have been a straight copy from WCAG. This PR reverts 1.4.10 Note 2 so it matches WCAG's text.