### PR TITLE
definition of 'set of web pages': add a missing cross-reference

### DIFF
--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -547,7 +547,7 @@ See the guidance on [set of documents](#set-of-documents) and [set of software p
 
 <div class="note">
 
-For success criteria that use the term “set of web pages”, either explicitly or implicitly ([2.4.1](#bypass-blocks), [2.4.5](#multiple-ways), [3.2.3](#consistent-navigation), and [3.2.4](#consistent-identification)), simply substitute "set of non-web documents" and "set of software programs" when applying this to non-web technologies.</div>
+For success criteria that use the term “set of web pages”, either explicitly or implicitly ([2.4.1](#bypass-blocks), [2.4.5](#multiple-ways), [3.2.3](#consistent-navigation), [3.2.4](#consistent-identification), and [3.2.6](#consistent-help)), simply substitute "set of non-web documents" and "set of software programs" when applying this to non-web technologies.</div>
 
 #### dfn-structure
 


### PR DESCRIPTION
The note listed four SCs when it should have had five.

That said, I wonder if "simply substitute" is actually helpful? Who is that instruction for? We (the WCAG2ICT Task Force) have actually already done the word substitutions, and it's not always been simple.