### PR TITLE
Add 'wcag2ict' to wcag2ict notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,6 @@
 		<section class="appendix" data-include="success-criteria-problematic-for-closed-functionality.md" data-include-format="markdown"></section>
 		<section class="appendix" data-include="background-on-text-command-line-terminal-applications-and-interfaces.md" data-include-format="markdown"></section>
 		<section class="appendix" data-include="acknowledgements.md" data-include-format="markdown"></section>
-	
+
 
 </body></html>

--- a/wcag2ict.css
+++ b/wcag2ict.css
@@ -9,3 +9,8 @@
 ins {
   text-decoration: none;
 }
+
+section[id*="applying"] > div.note > div[role="heading"] ::before,
+section[id*="applying"] > dl > dd > div.note > div[role="heading"] ::before {
+    content: "Wcag2ict ";
+}

--- a/wcag2ict.css
+++ b/wcag2ict.css
@@ -11,6 +11,7 @@ ins {
 }
 
 section[id*="applying"] > div.note > div[role="heading"] ::before,
-section[id*="applying"] > dl > dd > div.note > div[role="heading"] ::before {
+section[id*="applying"] > dl > dd > div.note > div[role="heading"] ::before,
+section[id*="applying"] > dl > dd > ol > li > div.note > div[role="heading"] ::before {
     content: "Wcag2ict ";
 }


### PR DESCRIPTION
This adds the word "WCAG2ICT" before any specific WCAG2ICT Note and Editor Note via the `before` CSS .
