### PR TITLE
Update privacy-considerations-removing-horizontal-review-phrasing.md

### DIFF
--- a/privacy-considerations.md
+++ b/privacy-considerations.md
@@ -1,3 +1,3 @@
 ## Privacy Considerations
 
-This Working Group Note does not introduce any new privacy considerations. Horizontal Review Groups are encouraged to provide further feedback during the Horizontal Review process.
+This Working Group Note does not introduce any new privacy considerations.

--- a/privacy-considerations.md
+++ b/privacy-considerations.md
@@ -1,3 +1,7 @@
 ## Privacy Considerations
 
-This Working Group Note does not introduce any new privacy considerations.
+This Working Group Note does not introduce any new privacy considerations. However, when implementing WCAG 2 success criteria in the context of non-web ICT, information about a user’s accessibility needs or preferences might be exposed; a user could be harmed by disclosure and misuse of that information. It is best practice to choose implementations that reduce the potential for fingerprinting or other identification and tracking of users, and that the only data collected is data necessary to enable the accessibility features.
+<div class='note'>
+
+The [WCAG 2 Privacy Considerations section](https://www.w3.org/TR/WCAG22/#privacy-summary) also notes specific success criteria that are identified to have possible implications for privacy that could also exist for non-web ICT.</div>
+


### PR DESCRIPTION
Task per https://github.com/w3c/wcag2ict/issues/447 to remove horizontal text phrasing. 

Additional changes added to address Issue #446 to amend the privacy considerations per the horizontal review. See the [TF resolution from 15 Aug.](https://www.w3.org/2024/08/15-wcag2ict-minutes#r03)