### PR TITLE
Update comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a-iss…

### DIFF
--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -368,7 +368,7 @@ With this substitution and addition, it would read:
 
 <div class="note">
 
-A label is presented to all users whereas the [name](#dfn-name) may be hidden and only exposed by assistive technology <INS>**[or by accessibility features of [software](#software)]**</INS>. In many (but not all) cases the name and the label are the same.</div>
+A label is presented to all users whereas the [name](#dfn-name) may be hidden and only exposed by assistive technology <INS>**[or by accessibility features of software]**</INS>. In many (but not all) cases the name and the label are the same.</div>
 <div class="note">
 
 The term label is not limited to the label element in HTML.</div></DD></DL>

--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -368,7 +368,7 @@ With this substitution and addition, it would read:
 
 <div class="note">
 
-A label is presented to all users whereas the [name](#dfn-name) may be hidden and only exposed by assistive technology <INS>**[or by accessibility features of software]**</INS>. In many (but not all) cases the name and the label are the same.</div>
+A label is presented to all users whereas the [name](#dfn-name) may be hidden and only exposed by assistive technology <INS>**[or by accessibility features of [software](#software)]**</INS>. In many (but not all) cases the name and the label are the same.</div>
 <div class="note">
 
 The term label is not limited to the label element in HTML.</div></DD></DL>

--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -105,7 +105,7 @@ supported by users' [assistive technologies](#dfn-assistive-technologies) as wel
 
 To qualify as an accessibility-supported use of a <INS>**[[non-web document](#document) or software]**</INS> [technology](#dfn-technologies) (or feature of a technology), both 1 and 2 must be satisfied for a <INS>**[non-web document or software]**</INS> technology (or feature):
 
-1.  **The way that the <INS>[non-web document or software technology]</INS> is used must be supported by users' assistive technology (AT).** This means that the way that the technology is used has been tested for interoperability with users' assistive technology in the [human language(s)](https://www.w3.org/TR/WCAG22/#dfn-human-language-s) of the [content](#content-on-and-off-the-web),
+1.  **The way that the <INS>[non-web document or software technology]</INS> is used must be supported by users' assistive technology (AT).** This means that the way that the technology is used has been tested for interoperability with users' assistive technology in the [human language(s)](https://www.w3.org/TR/WCAG22/#dfn-human-language-s) of the content,
     
     **AND**
     
@@ -188,13 +188,13 @@ Assistive technologies that are important in the context of this document includ
 
 ##### Applying “changes of context” to Non-Web Documents and Software
 
-This applies directly as written and as described in the WCAG 2 glossary, replacing “Web page” and “page” with “non-web document or content presented by software”.
+This applies directly as written and as described in the WCAG 2 glossary, replacing “page” with “non-web document or content presented by software”.
 
 With these substitutions, it would read:
 
 <DL><DT>changes of context</DT><DD>
 
-major changes in the content of the <INS>**[[non-web document](#document) or [content](#content-on-and-off-the-web) presented by [software](#software)]**</INS> that, if made without user awareness, can disorient users who are not able to view the entire <INS>**non-web document or content presented by software]**</INS> simultaneously
+major changes that, if made without user awareness, can disorient users who are not able to view the entire <INS>**non-web document or content presented by software]**</INS> simultaneously
 
 Changes in context include changes of:
 
@@ -204,7 +204,7 @@ Changes in context include changes of:
     
 3.  focus;
     
-4.  content that changes the meaning of the <INS>**[non-web document or content presented by software]**</INS>.  
+4.  [content](#dfn-content) that changes the meaning of the <INS>**[non-web document or content presented by software]**</INS>.  
 
 <div class="note">
 
@@ -406,7 +406,7 @@ With this substitution and addition, it would read:
 
 <DL><DT>programmatically determined (programmatically determinable)</DT><DD>
 
-determined by [software](#software) from author-supplied data provided in a way that different <INS>**[[assistive technologies](#dfn-assistive-technologies) and accessibility features of software]**</INS> can extract and present this information to users in different modalities
+determined by software from author-supplied data provided in a way that different <INS>**[[assistive technologies](#dfn-assistive-technologies) and accessibility features of software]**</INS> can extract and present this information to users in different modalities
 
 <div class="example">
 
@@ -447,11 +447,11 @@ With this substitution, it would read:
 
 the relative brightness of any point in a colorspace, normalized to 0 for darkest black and 1 for lightest white
 
-<div class="note">For the sRGB colorspace, the relative luminance of a color is defined as L = 0.2126 \* **R** + 0.7152 \* **G** + 0.0722 \* **B** where **R**, **G** and **B** are defined as:
+<div class="note">For the sRGB colorspace, the relative luminance of a color is defined as L = 0.2126 * <strong>R</strong> + 0.7152 * <strong>G</strong> + 0.0722 * <strong>B</strong> where <strong>R</strong>, <strong>G</strong> and <strong>B</strong> are defined as:
 
-- if RsRGB <= 0.03928 then **R** = RsRGB/12.92 else **R** = ((RsRGB+0.055)/1.055) ^ 2.4
-- if GsRGB <= 0.03928 then **G** = GsRGB/12.92 else **G** = ((GsRGB+0.055)/1.055) ^ 2.4
-- if BsRGB <= 0.03928 then **B** = BsRGB/12.92 else **B** = ((BsRGB+0.055)/1.055) ^ 2.4  
+- if RsRGB <= 0.04045 then __R__ = RsRGB/12.92 else __R__ = ((RsRGB+0.055)/1.055) ^ 2.4
+- if GsRGB <= 0.04045 then __G__ = GsRGB/12.92 else __G__ = ((GsRGB+0.055)/1.055) ^ 2.4
+- if BsRGB <= 0.04045 then __B__ = BsRGB/12.92 else __B__ = ((BsRGB+0.055)/1.055) ^ 2.4  
 
 and RsRGB, GsRGB, and BsRGB are defined as:
 
@@ -459,7 +459,7 @@ and RsRGB, GsRGB, and BsRGB are defined as:
 - GsRGB = G8bit/255
 - BsRGB = B8bit/255
     
-The “^” character is the exponentiation operator. (Formula taken from [\[sRGB\]](http://www.w3.org/TR/WCAG22/#bib-srgb)).</div>
+The “^” character is the exponentiation operator. (Formula taken from [\[sRGB\]](http://www.w3.org/TR/WCAG22/#bib-srgb).)</div>
 <div class="note">Before May 2021 the value of 0.04045 in the definition was different (0.03928). It was taken from an older version of the specification and has been updated. It has no practical effect on the calculations in the context of these guidelines.</div>
 <div class="note">
 
@@ -472,7 +472,7 @@ If dithering occurs after delivery, then the source color value is used. For col
 Tools are available that automatically do the calculations when testing contrast and flash.</div>
 <div class="note">
     
-A [MathML version of the relative luminance definition](http://www.w3.org/TR/WCAG22/relative-luminance.html) is available.</div>
+A [separate page giving the relative luminance definition using MathML](https://www.w3.org/TR/WCAG22/relative-luminance.html) to display the formulas is available.</div>
 </DD></DL>
 
 <div class="note">Because relative luminance is defined such that it cannot directly apply to hardware, please note the text in the introduction which reads: “This document does not comment on hardware aspects of products, because the basic constructs on which WCAG 2 is built do not apply to these.”</div>
@@ -511,7 +511,7 @@ same result when used
 
 <div class="example"> 
 
-A submit “search” button on one web page and a “find” button on another web page may both have a field to enter a term and list topics in the Web site related to the term submitted. In this case, they would have the same functionality but would not be labeled consistently.</div>
+A submit “search” button on one Web page and a “find” button on another Web page may both have a field to enter a term and list topics in the Web site related to the term submitted. In this case, they would have the same functionality but would not be labeled consistently.</div>
 <div class="example">
 
 A ribbon icon that saves the document that looks like an arrow pointing into a folder in one case, and an arrow pointing into a hard drive in another. In this case as well, they would have the same functionality but would not be labeled consistently.</div></DD></DL>
@@ -632,7 +632,7 @@ With this substitution, it would read:
 
 <DL><DT>user interface component</DT><DD>
 
-a part of the [content](#content-on-and-off-the-web) that is perceived by users as a single control for a distinct function
+a part of the content that is perceived by users as a single control for a distinct function
 
 <div class="note">
 
@@ -658,14 +658,14 @@ With this substitution, it would read:
 
 <DL><DT>viewport</DT><DD>
 
-object in which the <INS>**[[software](#software)]**</INS> presents [content](#content-on-and-off-the-web)
+object in which the <INS>**[[software](#software)]**</INS> presents content
 
 <div class="note">
 
 The <INS>**[software]**</INS> presents content through one or more viewports. Viewports include windows, frames, loudspeakers, and virtual magnifying glasses. A viewport may contain another viewport (e.g., nested frames). Interface components created by the <INS>**[software]**</INS> such as prompts, menus, and alerts are not viewports.</div>
 <div class="note">
 
-This definition is based on [User Agent Accessibility Guidelines 1.0 Glossary](http://www.w3.org/TR/WAI-USERAGENT/glossary.html).</div>
+This definition is based on [User Agent Accessibility Guidelines 1.0 Glossary](http://www.w3.org/TR/WAI-USERAGENT/glossary.html) [\[UAAG10\]](https://www.w3.org/TR/WCAG22/#bib-uaag10).</div>
 </DD></DL>
 
 #### dfn-web-page-s

--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -194,7 +194,7 @@ With these substitutions, it would read:
 
 <DL><DT>changes of context</DT><DD>
 
-major changes that, if made without user awareness, can disorient users who are not able to view the entire <INS>**non-web document or content presented by software]**</INS> simultaneously
+major changes that, if made without user awareness, can disorient users who are not able to view the entire <INS>**[non-web document](#document) or [content](#content-on-and-off-the-web) presented by [software](#software)]**</INS> simultaneously
 
 Changes in context include changes of:
 


### PR DESCRIPTION
…ue412-fixDefinitions.md

Fixing typos that introduced inconsistency between WCAG and quotes with substitutions in WCAG2ICT.

- [x] Definition of 'accessibility supported': In bullet (1), 'content' has a glossary link added in WCAG2ICT, which is not there in WCAG
- [x] Definition of 'changes of context':
    - WCAG changed "major changes in the content of the Web page" to "major changes" 
    - In bullet (4), 'content' has a glossary link in WCAG, which is not there in WCAG2ICT
- [x] Definition of 'relative luminance':
    - In WCAG2ICT, in Note 1, the text before the first unordered list has extra slash and asterisk characters. (Phil note: I had to use inline HTML to fix this) 
    - WCAG changed the red threshold from 0.03928 to 0.04045 
    - At the end of Note 1, ")." should be ".)"
    - WCAG has changed Note 6.
- [x] Definition of 'programmatically determined': "Software" has a glossary link added in WCAG2ICT, which is not there in WCAG.
- [x] Definition of 'same functionality': Two instances of the word 'Web' should be capitalized
- [x] Definition of 'user interface component': "content" has a glossary link added in WCAG2ICT, which is not there in WCAG.
- [x] Definition of 'viewport':
    - "content" has a glossary link added in WCAG2ICT, which is not there in WCAG. 
    - Note 2 in WCAG2ICT is missing a footnote link to WCAG.