### PR TITLE
Update comments-by-guideline-and-success-criterion.md - remove extra …

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -119,7 +119,7 @@ This applies directly as written, and as described in [Intent from Understanding
 In software, programmatic determinability is best achieved through the use of [accessibility services provided by platform software](#accessibility-services-of-platform-software) to enable interoperability between software and assistive technologies and accessibility features of software.</div>
 <div class="note wcag2ict">
     
-See also the [Comments on Closed Functionality](#comments-on-closed-functionality)).</div>
+See also the [Comments on Closed Functionality](#comments-on-closed-functionality).</div>
 
 ##### meaningful-sequence
 


### PR DESCRIPTION
…parenthesis from 1.3.1 NOTE 2

Minor editorial 

Applying SC 1.3.1
Typo in NOTE 2 - need to delete extra parenthesis after Functionality

NOTE 2 (ADDED)
See also the Comments on Closed Functionality).