### PR TITLE
Issue 421: Update SC 2.1.1 Keyboard & "keyboard interface" Note 1 per TF resolution

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -392,7 +392,7 @@ This applies directly as written, and as described in [Intent from Understanding
 
 <div class="note wcag2ict">
     
-Keyboard interface does not refer to a physical device but to the interface between the software and any keyboard or keyboard substitute (i.e., an interface where the software accepts text or other keystroke input). [Platform software](#platform-software) may provide device independent input services to applications that enable operation via such a keyboard interface. Software that supports operation via such platform device independent services would be operable via a keyboard interface and would satisfy the success criterion.</div>
+Keyboard interface does not refer to a physical device but to the interface between the software and any keyboard or keyboard substitute (i.e., the interface where the software accepts text or other keystroke input from the platform which may come from a keyboard or from a keyboard alternative). [Platform software](#platform-software) may provide device independent input services to applications that enable operation via such a keyboard interface. When software supports such a device-independent service of the platform, and the software or non-web document functionality is made fully operable through the service, then this success criterion would be satisfied.</div>
 <div class="note wcag2ict">
 
 This success criterion does not imply that software always needs to directly support a keyboard or “keyboard interface”. Nor does it imply that software always needs to provide a [virtual keyboard](#virtual-keyboard).</div>

--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -345,7 +345,7 @@ This applies directly as written and as described in the WCAG 2 glossary.
 
 <div class="note wcag2ict">
 
-Keyboard interface does not refer to a physical device but to the interface between the software and any keyboard or keyboard substitute (i.e., an interface where the software accepts text or other keystroke input). [Platform software](#platform-software) may provide device independent input services to applications that enable operation via such a keyboard interface. [Software](#software) that supports operation via such platform device independent services would be operable via a keyboard interface and would satisfy the success criterion.</div>
+Keyboard interface does not refer to a physical device but to the interface between the software and any keyboard or keyboard substitute (i.e., the interface where the software accepts text or other keystroke input from the platform which may come from a keyboard or from a keyboard alternative). [Platform software](#platform-software) may provide device independent input services to applications that enable operation via such a keyboard interface.</div>
 <div class="note wcag2ict">
 
 This success criterion does not imply that software always needs to directly support a keyboard or “keyboard interface”. Nor does it imply that software always needs to provide a [virtual keyboard](#virtual-keyboard).</div>


### PR DESCRIPTION
See Issue #421, and the two resolutions:
1. [29 Aug. resolution for 'keyboard interface'  definition](https://www.w3.org/2024/08/29-wcag2ict-minutes.html#r03) to remove the last sentence from Note 1 and add to the parenthetic statement to the definition of 'keyboard interface'.
2. [29 Aug.resolution for SC 2.1.1 Keyboard](https://www.w3.org/2024/08/29-wcag2ict-minutes.html#r04) to update Note 1 to change the parenthetic statement in 2.1.1 Keyboard for consistency with the definition, but keeping the last sentence of the note.