### PR TITLE
Remove the sole link to a term

### DIFF
--- a/success-criteria-problematic-for-closed-functionality.md
+++ b/success-criteria-problematic-for-closed-functionality.md
@@ -70,6 +70,6 @@ For non-web software on products with closed functionality, those who implement 
 </ul>
 </li>
 <li><a href="#name-role-value">4.1.2 Name, Role, Value</a> — Requires information in a programmatically determinable form.</li>
-<li><a href="#status-messages">4.1.3 Status Messages</a> — Depends upon status messages being programmatically determinable using <a href="#dfn-role">role</a> or properties.
+<li><a href="#status-messages">4.1.3 Status Messages</a> — Depends upon status messages being programmatically determinable using role or properties.
 <div class="note">Non-web software with closed functionality would need equivalent facilitation to provide access to status messages.</div></li>
 </ul>


### PR DESCRIPTION
This PR removes a glossary link for the word 'role'. The reason for this PR is for consistency. There are quite a few other terms throughout the 'problematic' section that have glossary definitions, yet for no apparent reason only this one word had a link.

I believe this change is editorial. However, @maryjom if you feel this would be a substantive change, feel free to reject this PR or have it reviewed.