### PR TITLE
update funder acks in acknowledgements.md

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -78,9 +78,7 @@ The following people contributed to the development of the 2013 WCAG2ICT Note.
 Shadi Abou-Zahra, Bruce Bailey, Judy Brewer, Michael Cooper, Pierce Crowell, Allen Hoffman, Kiran Kaja, Andrew Kirkpatrick, Peter Korn, Alex Li, David MacDonald, Mary Jo Mueller, Loïc Martínez Normand, Mike Pluke, Janina Sajka, Andi Snow-Weaver, Gregg Vanderheiden
 
 ### Enabling Funders
-This publication has been funded in part by funds from the following projects and contracts:
 
-* U.S. Federal funds from the Health and Human Services, National Institute on Disability, Independent Living, and Rehabilitation Research (NIDILRR), under contract number HHS75P00120P00168. 
-* [WAI-CooP Project](https://www.w3.org/WAI/about/projects/wai-coop/), co-funded by the European Commission (EC) under the Horizon 2020 program.
+This publication has been funded in part with U.S. Federal funds from the Health and Human Services, National Institute on Disability, Independent Living, and Rehabilitation Research (NIDILRR), initially under contract number ED-OSE-10-C-0067 and now under HHS75P00120P00168. The content of this publication does not necessarily reflect the views or policies of the U.S. Department of Health and Human Services or the U.S. Department of Education, nor does mention of trade names, commercial products, or organizations imply endorsement by the U.S. Government.
 
-The content of this publication does not necessarily reflect the views or policies of the Health and Human Services, National Institute on Disability, Independent Living, and Rehabilitation Research (NIDILRR), and/or the European Commission, nor does mention of trade names, commercial products, or organizations imply endorsement by the aforementioned organizations.
+Work on this publication was part of the [WAI-CooP Project](https://www.w3.org/WAI/about/projects/wai-coop/), a European Commission (EC) co-funded project, Horizon 2020 Program (101004794).


### PR DESCRIPTION
Hi @daniel-montalvo 

Correction from what I said earlier:  We should also include the US funding that was in the first version.

This PR also puts the US funding wording together. And removes the unvetted intro sentence.

OK?