### PR TITLE
Update Comparison with the 2013 Note to remove "encloses"

### DIFF
--- a/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
+++ b/comments-on-definitions-in-wcag-2.2-glossary-in-appendix-a.md
@@ -22,7 +22,6 @@ The following glossary items apply to all technologies and do not need further i
 *   correct reading sequence
 *   dragging movements
 *   emergency
-*   encloses
 *   essential
 *   extended audio description
 *   flash

--- a/introduction.md
+++ b/introduction.md
@@ -100,7 +100,7 @@ The following changes and additions have been made to update the 2013 WCAG2ICT d
 * Obsolete and Removed WCAG 2.2 success criteria that have errata for WCAG 2.0 and 2.1
     * [Success Criterion 4.1.1 Parsing](#parsing22)
 * New terms from WCAG 2.1 and 2.2
-    * dragging movements, encloses, focus indicator, minimum bounding box, pointer input, process, single pointer, state, and status message were added to [Glossary Items that Apply to All Technologies](#glossary-items-that-apply-to-all-technologies)
+    * dragging movements, focus indicator, minimum bounding box, pointer input, process, single pointer, state, and status message were added to [Glossary Items that Apply to All Technologies](#glossary-items-that-apply-to-all-technologies)
     * motion animation, perimeter, region, and user inactivity were added to [Glossary Items Used only in AAA Success Criteria](#glossary-items-used-only-in-aaa-success-criteria)
     * added to [Glossary Items with Specific Guidance](#glossary-items-with-specific-guidance): 
         * [cognitive function test](#dfn-cognitive-function-test)


### PR DESCRIPTION
Unused dictionary term "encloses" was removed in December 2024 version of WCAG 2.2.