### PR TITLE
Add treatment for notes specific for either non-web documents or non-web software

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -108,13 +108,11 @@ In WCAG 2, the Guidelines are provided for framing and understanding the success
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.3.1](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships#intent).
 
-(for non-web documents)
-<div class="note wcag2ict">
+<div class="note wcag2ict documents">
 	
 Where non-web documents contain non-standard structure types (roles), it is best practice to map them to a standard structure type as a fall-back solution for the reader.</div>
 
-(for non-web software)
-<div class="note wcag2ict">
+<div class="note wcag2ict software">
     
 In non-web software, programmatic determinability is best achieved by using the [accessibility services of platform software](#accessibility-services-of-platform-software) to enable interoperability between the software and assistive technologies and accessibility features of software.</div>
 <div class="note wcag2ict">

--- a/wcag2ict.js
+++ b/wcag2ict.js
@@ -301,6 +301,12 @@ function furtherProcessNotesAndExamples() {
         if (note.querySelector(".original")) {
             noteTitle = noteTitle + " (Original)";
         }
+        if (note.querySelector(".wcag2ict.documents")) {  
+            noteTitle = noteTitle + " (for non-web documents)";
+        }
+        if (note.querySelector(".wcag2ict.software")) {  
+            noteTitle = noteTitle + " (for non-web software)";
+        }
         note.querySelector("div > span").textContent = noteTitle;
     })
     let wcag2ictExamples = document.querySelectorAll("div.example.wcag2ict");


### PR DESCRIPTION
This moves the parenthetical statement "For non-web documents" or "for non-web software" from before the note heading to inside the note heading. For example, see guidance for SC 1.3.1