### PR TITLE
[Editorial] Make further updates for notes to mark for docs or sw only

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -221,7 +221,7 @@ The Intent section refers to the ability to allow users to enlarge the text on s
 	
 For non-web software, there may be cases where the platform does not scale all text up to 200%. In such cases, authors are encouraged to meet user needs by scaling text to the extent supported by user settings in the platform.</div>
 
-<div class="note wcag2ict">
+<div class="note wcag2ict software">
 
 See also the [Comments on Closed Functionality](#comments-on-closed-functionality).</div>
 


### PR DESCRIPTION
See Issues #725, #713. There's some corrections needed that were missed, or markup accidentally deleted when marking notes as only for software or only for documents.