### PR TITLE
[Editorial] Add precondition scoping to software on platforms with a keyboard interface service

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -385,7 +385,7 @@ In WCAG 2, the Guidelines are provided for framing and understanding the success
 
 ###### Applying SC 2.1.1 Keyboard to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.1.1](https://www.w3.org/WAI/WCAG22/Understanding/keyboard#intent).
+Where ICT is or includes non-web software that can be run on a software platform that provides a device-independent keyboard interface service, this applies directly as written, and as described in [Intent from Understanding Success Criterion 2.1.1](https://www.w3.org/WAI/WCAG22/Understanding/keyboard#intent).
 
 <div class="note wcag2ict software">
 	


### PR DESCRIPTION
Per issue #740, not all non-web software runs on a platform with device-independent keyboard interface services. In a Web context this is assumed (since that is viewed in a software stack with a browser layer and an underlying platform that has such services). When applied to all non-web software, this is not always the case that there are such software layers.