### PR TITLE
Add note describing device-independent keyboard interface services

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -392,11 +392,15 @@ This applies directly as written, and as described in [Intent from Understanding
 Keyboard interface does not refer to a physical device but to the service of [platform software](#platform-software) (e.g. operating system, browser, etc.) that provides the software with keystrokes from any keyboard or keyboard substitute. When the [non-web software](#software) supports such a device-independent service of the platform software, and the non-web software functionality is made fully operable through the service, then this success criterion would be satisfied.</div>
 <div class="note wcag2ict software">
 
-**Proposal 1:** Do not add any more notes.</div>
-<div class="note wcag2ict software">**Proposal 2: Note describing keyboard interface service** 
+**Proposal 1: Do not add any more notes.**</div>
+<div class="note wcag2ict software">
+	
+**Proposal 2: Note describing keyboard interface service** 
 	
 A "device-independent keyboard interface service" refers to the platform service that provides keystrokes to any software running on the platform. Inclusion of an on-screen keyboard can be done as well but does not meet this requirement since it does not allow for the use of keyboard alternatives.</div>
-<div class="note wcag2ict software">**Proposal 3: Edited version of Proposal 2 (removing last sentence)** 
+<div class="note wcag2ict software">
+	
+**Proposal 3: Edited version of Proposal 2 (removing last sentence)** 
 	
 A "device-independent keyboard interface service" refers to the platform service that provides keystrokes to any software running on the platform.</div>
 <div class="note wcag2ict software">

--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -390,6 +390,13 @@ This applies directly as written, and as described in [Intent from Understanding
 <div class="note wcag2ict software">
 	
 Keyboard interface does not refer to a physical device but to the service of [platform software](#platform-software) (e.g. operating system, browser, etc.) that provides the software with keystrokes from any keyboard or keyboard substitute. When the [non-web software](#software) supports such a device-independent service of the platform software, and the non-web software functionality is made fully operable through the service, then this success criterion would be satisfied.</div>
+<div class="note wcag2ict software">**Proposal 1:** Do not add any more notes.</div>
+<div class="note wcag2ict software">**Proposal 2: Note describing keyboard interface service** 
+	
+A "device-independent keyboard interface service" refers to the platform service that provides keystrokes to any software running on the platform. Inclusion of an on-screen keyboard can be done as well but does not meet this requirement since it does not allow for the use of keyboard alternatives.</div>
+<div class="note wcag2ict software">**Proposal 3: Edited version of Proposal 2 (removing last sentence)** 
+	
+A "device-independent keyboard interface service" refers to the platform service that provides keystrokes to any software running on the platform.</div>
 <div class="note wcag2ict software">
 
 This success criterion does not imply that non-web software always needs to directly support a keyboard or “keyboard interface” if one is not provided by the platform software. But if one is provided, the software needs to make all functionality available through it - unless the exception applies.</div>

--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -391,22 +391,12 @@ Where ICT is or includes non-web software that can be run on a software platform
 	
 Keyboard interface does not refer to a physical device but to the service of [platform software](#platform-software) (e.g. operating system, browser, etc.) that provides the software with keystrokes from any keyboard or keyboard substitute. When the [non-web software](#software) supports such a device-independent service of the platform software, and the non-web software functionality is made fully operable through the service, then this success criterion would be satisfied.</div>
 <div class="note wcag2ict software">
-
-**Proposal 1: Do not add any more notes.**</div>
-<div class="note wcag2ict software">
-	
-**Proposal 2: Note describing keyboard interface service** 
 	
 A "device-independent keyboard interface service" refers to the platform service that provides keystrokes to any software running on the platform.</div>
 
 <div class="note wcag2ict software">
 
 Inclusion of an on-screen keyboard can be done as well but does not satisfy this requirement since it does not allow for the use of keyboard alternatives whereas support of input from the device-independent keyboard interface service does.</div>
-<div class="note wcag2ict software">
-	
-**Proposal 3: Edited version of Proposal 2 (removing last sentence)** 
-	
-A "device-independent keyboard interface service" refers to the platform service that provides keystrokes to any software running on the platform.</div>
 <div class="note wcag2ict software">
 
 This success criterion does not imply that non-web software always needs to directly support a keyboard or “keyboard interface” if one is not provided by the platform software. But if one is provided, the software needs to make all functionality available through it - unless the exception applies.</div>

--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -390,7 +390,9 @@ This applies directly as written, and as described in [Intent from Understanding
 <div class="note wcag2ict software">
 	
 Keyboard interface does not refer to a physical device but to the service of [platform software](#platform-software) (e.g. operating system, browser, etc.) that provides the software with keystrokes from any keyboard or keyboard substitute. When the [non-web software](#software) supports such a device-independent service of the platform software, and the non-web software functionality is made fully operable through the service, then this success criterion would be satisfied.</div>
-<div class="note wcag2ict software">**Proposal 1:** Do not add any more notes.</div>
+<div class="note wcag2ict software">
+
+**Proposal 1:** Do not add any more notes.</div>
 <div class="note wcag2ict software">**Proposal 2: Note describing keyboard interface service** 
 	
 A "device-independent keyboard interface service" refers to the platform service that provides keystrokes to any software running on the platform. Inclusion of an on-screen keyboard can be done as well but does not meet this requirement since it does not allow for the use of keyboard alternatives.</div>

--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -385,7 +385,7 @@ In WCAG 2, the Guidelines are provided for framing and understanding the success
 
 ###### Applying SC 2.1.1 Keyboard to Non-Web Documents and Software
 
-This applies directly as written, and as described in [Intent from Understanding Success Criterion 2.1.1](https://www.w3.org/WAI/WCAG22/Understanding/keyboard#intent).
+Where ICT is or includes non-web software that can be run on a software platform that provides a device-independent keyboard interface service, this applies directly as written, and as described in [Intent from Understanding Success Criterion 2.1.1](https://www.w3.org/WAI/WCAG22/Understanding/keyboard#intent).
 
 <div class="note wcag2ict software">
 	

--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -397,7 +397,11 @@ Keyboard interface does not refer to a physical device but to the service of [pl
 	
 **Proposal 2: Note describing keyboard interface service** 
 	
-A "device-independent keyboard interface service" refers to the platform service that provides keystrokes to any software running on the platform. Inclusion of an on-screen keyboard can be done as well but does not meet this requirement since it does not allow for the use of keyboard alternatives.</div>
+A "device-independent keyboard interface service" refers to the platform service that provides keystrokes to any software running on the platform.</div>
+
+<div class="note wcag2ict software">
+
+Inclusion of an on-screen keyboard can be done as well but does not satisfy this requirement since it does not allow for the use of keyboard alternatives whereas support of input from the device-independent keyboard interface service does.</div>
 <div class="note wcag2ict software">
 	
 **Proposal 3: Edited version of Proposal 2 (removing last sentence)** 


### PR DESCRIPTION
Per the [comment](https://github.com/w3c/wcag2ict/issues/740#issuecomment-3113842221) in issue #740 this PR is to provide a note describing what a 'device-independent keyboard interface service" is.