### PR TITLE
[Editorial] Make notes consistent when using the phrase "contrast requirements for hardware"

### DIFF
--- a/success-criteria-problematic-for-closed-functionality.md
+++ b/success-criteria-problematic-for-closed-functionality.md
@@ -19,7 +19,7 @@ For non-web software on ICT with closed functionality, those who implement this 
 <li><a href="#contrast-minimum">1.4.3 Contrast (Minimum)</a> — There are cases where applying this success criterion to non-web software on ICT with closed functionality is problematic:
 <ul>
 <li>When the contrast of the content is determined by the hardware and not modifiable by the software author, it may not be possible to meet this success criterion.
-<div class="note">Hardware requirements for contrast are out of scope for WCAG2ICT (and this success criterion).</div></li>
+<div class="note">Contrast requirements for hardware are out of scope for WCAG2ICT (and this success criterion).</div></li>
 <li>When the color contrast ratio cannot be programmatically measured due to system limitations (e.g. lockdown), precise quantifiable testing of color contrast cannot be performed by a third party.  In such cases, the software author would need to confirm that the color combinations used meet the contrast requirement.
 <div class="note">Photographs (e.g., of a hardware display) are not sufficient for testing that content meets this success criterion.  This is because the quality of the lighting, camera, and physical aspects of the hardware display can dramatically affect the ability to capture the content for testing purposes.</div></li>
 </ul></li>
@@ -31,7 +31,7 @@ For non-web software on ICT with closed functionality, those who implement this 
 <li><a href="#non-text-contrast">1.4.11 Non-text Contrast</a> — There are cases where applying this success criterion to non-web software on ICT with closed functionality is problematic:
 <ul>
 <li>When the contrast of the content is determined by the hardware and not modifiable by the software author, it may not be possible to meet this success criterion.
-<div class="note">Hardware requirements for contrast are out of scope for WCAG2ICT (and this success criterion).</div></li>
+<div class="note">Contrast requirements for hardware are out of scope for WCAG2ICT (and this success criterion).</div></li>
 <li>When the color contrast ratio cannot be programmatically measured due to system limitations (e.g. lockdown), precise quantifiable testing of color contrast cannot be performed by a third party. In such cases, the software author would need to confirm that the color combinations used meet the contrast requirement.
 <div class="note">Photographs are not sufficient for testing that content meets this success criterion.  This is because the quality of the lighting, camera, and physical aspects of the hardware display can dramatically affect the ability to capture the content for testing purposes.</div></li>
 </ul></li>

--- a/success-criteria-problematic-for-closed-functionality.md
+++ b/success-criteria-problematic-for-closed-functionality.md
@@ -19,7 +19,7 @@ For non-web software on ICT with closed functionality, those who implement this 
 <li><a href="#contrast-minimum">1.4.3 Contrast (Minimum)</a> — There are cases where applying this success criterion to non-web software on ICT with closed functionality is problematic:
 <ul>
 <li>When the contrast of the content is determined by the hardware and not modifiable by the software author, it may not be possible to meet this success criterion.
-<div class="note">Contrast requirements for hardware are out of scope for WCAG2ICT (and this success criterion).</div></li>
+<div class="note">Hardware requirements for contrast are out of scope for WCAG2ICT (and this success criterion).</div></li>
 <li>When the color contrast ratio cannot be programmatically measured due to system limitations (e.g. lockdown), precise quantifiable testing of color contrast cannot be performed by a third party.  In such cases, the software author would need to confirm that the color combinations used meet the contrast requirement.
 <div class="note">Photographs (e.g., of a hardware display) are not sufficient for testing that content meets this success criterion.  This is because the quality of the lighting, camera, and physical aspects of the hardware display can dramatically affect the ability to capture the content for testing purposes.</div></li>
 </ul></li>


### PR DESCRIPTION
From Editor’s Draft 1 August 2025, appendix [A. Success Criteria Problematic for Closed Functionality](https://w3c.github.io/wcag2ict/#success-criteria-problematic-for-closed-functionality), under SC specific notes:

1.4.3 (Note 1):
> Contrast requirements for hardware are out of scope for WCAG2ICT (and this success criterion).

1.4.11 (Note 4):
> Hardware requirements for contrast are out of scope for WCAG2ICT (and this success criterion).

This PR uses the 1.4.3 version of the note for 1.4.11.

This description and PR updated 8/7 following TF call.
<del>I prefer 1.4.11 note phrasing with ‘hardware‘ at start of sentence.</del>