### PR TITLE
[Editorial] Make notes on contrast consistent

### DIFF
--- a/respec-config.js
+++ b/respec-config.js
@@ -1,22 +1,30 @@
 var respecConfig = {
 	noRecTrack: true,
 	tocIntroductory: true,
-	specStatus: "ED",
+	specStatus: "NOTE",
 	maxTocLevel: 3,
 	shortName: "wcag2ict-22",
 	
-	//publishDate:  "",
+	publishDate:  "2025-08-21",
 	copyrightStart: "2022",
 	license: "document",
 	
-	previousPublishDate:  "2013-09-05",
+	previousPublishDate:  "2024-11-15",
 	previousMaturity:  "NOTE",
 	otherLinks: [
 		{
 			key: "Previous Version",
 			data: [
 				{
-					href: "https://www.w3.org/TR/wcag2ict-20/",
+					href: "https://www.w3.org/TR/2024/NOTE-wcag2ict-22-20241115/",
+				},
+			],
+		},
+		{
+			key: "WCAG2ICT 2.0 W3C Group Note",
+			data: [
+				{
+					href: "https://www.w3.org/TR/wcag2ict/",
 				},
 			],
 		},

--- a/respec-config.js
+++ b/respec-config.js
@@ -5,7 +5,7 @@ var respecConfig = {
 	maxTocLevel: 3,
 	shortName: "wcag2ict-22",
 	
-	publishDate:  "",
+	//publishDate:  "",
 	copyrightStart: "2022",
 	license: "document",
 	

--- a/respec-config.js
+++ b/respec-config.js
@@ -24,7 +24,7 @@ var respecConfig = {
 			key: "WCAG2ICT 2.0 W3C Group Note",
 			data: [
 				{
-					href: "https://www.w3.org/TR/wcag2ict/",
+					href: "https://www.w3.org/TR/wcag2ict-20/",
 				},
 			],
 		},

--- a/respec-config.js
+++ b/respec-config.js
@@ -5,7 +5,7 @@ var respecConfig = {
 	maxTocLevel: 3,
 	shortName: "wcag2ict-22",
 	
-	publishDate:  "2025-08-21",
+	publishDate:  "",
 	copyrightStart: "2022",
 	license: "document",
 	

--- a/respec-config.js
+++ b/respec-config.js
@@ -1,7 +1,7 @@
 var respecConfig = {
 	noRecTrack: true,
 	tocIntroductory: true,
-	specStatus: "NOTE",
+	specStatus: "ED",
 	maxTocLevel: 3,
 	shortName: "wcag2ict-22",
 	

--- a/success-criteria-problematic-for-closed-functionality.md
+++ b/success-criteria-problematic-for-closed-functionality.md
@@ -19,7 +19,7 @@ For non-web software on ICT with closed functionality, those who implement this 
 <li><a href="#contrast-minimum">1.4.3 Contrast (Minimum)</a> — There are cases where applying this success criterion to non-web software on ICT with closed functionality is problematic:
 <ul>
 <li>When the contrast of the content is determined by the hardware and not modifiable by the software author, it may not be possible to meet this success criterion.
-<div class="note">Hardware requirements for contrast are out of scope for WCAG2ICT (and this success criterion).</div></li>
+<div class="note">Contrast requirements for hardware are out of scope for WCAG2ICT (and this success criterion).</div></li>
 <li>When the color contrast ratio cannot be programmatically measured due to system limitations (e.g. lockdown), precise quantifiable testing of color contrast cannot be performed by a third party.  In such cases, the software author would need to confirm that the color combinations used meet the contrast requirement.
 <div class="note">Photographs (e.g., of a hardware display) are not sufficient for testing that content meets this success criterion.  This is because the quality of the lighting, camera, and physical aspects of the hardware display can dramatically affect the ability to capture the content for testing purposes.</div></li>
 </ul></li>
@@ -31,7 +31,7 @@ For non-web software on ICT with closed functionality, those who implement this 
 <li><a href="#non-text-contrast">1.4.11 Non-text Contrast</a> — There are cases where applying this success criterion to non-web software on ICT with closed functionality is problematic:
 <ul>
 <li>When the contrast of the content is determined by the hardware and not modifiable by the software author, it may not be possible to meet this success criterion.
-<div class="note">Hardware requirements for contrast are out of scope for WCAG2ICT (and this success criterion).</div></li>
+<div class="note">Contrast requirements for hardware are out of scope for WCAG2ICT (and this success criterion).</div></li>
 <li>When the color contrast ratio cannot be programmatically measured due to system limitations (e.g. lockdown), precise quantifiable testing of color contrast cannot be performed by a third party. In such cases, the software author would need to confirm that the color combinations used meet the contrast requirement.
 <div class="note">Photographs are not sufficient for testing that content meets this success criterion.  This is because the quality of the lighting, camera, and physical aspects of the hardware display can dramatically affect the ability to capture the content for testing purposes.</div></li>
 </ul></li>

--- a/success-criteria-problematic-for-closed-functionality.md
+++ b/success-criteria-problematic-for-closed-functionality.md
@@ -19,7 +19,7 @@ For non-web software on ICT with closed functionality, those who implement this 
 <li><a href="#contrast-minimum">1.4.3 Contrast (Minimum)</a> — There are cases where applying this success criterion to non-web software on ICT with closed functionality is problematic:
 <ul>
 <li>When the contrast of the content is determined by the hardware and not modifiable by the software author, it may not be possible to meet this success criterion.
-<div class="note">Contrast requirements for hardware are out of scope for WCAG2ICT (and this success criterion).</div></li>
+<div class="note">Hardware requirements for contrast are out of scope for WCAG2ICT (and this success criterion).</div></li>
 <li>When the color contrast ratio cannot be programmatically measured due to system limitations (e.g. lockdown), precise quantifiable testing of color contrast cannot be performed by a third party.  In such cases, the software author would need to confirm that the color combinations used meet the contrast requirement.
 <div class="note">Photographs (e.g., of a hardware display) are not sufficient for testing that content meets this success criterion.  This is because the quality of the lighting, camera, and physical aspects of the hardware display can dramatically affect the ability to capture the content for testing purposes.</div></li>
 </ul></li>


### PR DESCRIPTION
From Editor’s Draft 1 August 2025, appendix [A. Success Criteria Problematic for Closed Functionality](https://w3c.github.io/wcag2ict/#success-criteria-problematic-for-closed-functionality), under SC specific notes:

1.4.3 (Note 1):
> Contrast requirements for hardware are out of scope for WCAG2ICT (and this success criterion).

1.4.11 (Note 4):
> Hardware requirements for contrast are out of scope for WCAG2ICT (and this success criterion).

This PR uses the first version of the note on contrast for both.

The PR is duplicative of #751 — as I was not sure which branch to build from.