### PR TITLE
1.4.10 Reflow: Remove Note 5 from non-web documents

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -271,12 +271,6 @@ In technologies where CSS is not used, the definition of 'CSS pixel' applies as 
 <div class="note wcag2ict documents">
 
 If a [non-web document](#document) type and its available [user agents](#user-agent) do not support reflow, it may not be possible for a document of that type to satisfy this success criterion.</div>
-<div class="note wcag2ict documents">
-
-As written, this success criterion can only be met by non-web documents where the underlying user agent or platform software can present content at a width equivalent to 320 CSS pixels for vertical scrolling content and a height equivalent to 256 CSS pixels for horizontal scrolling content.
-
-When the underlying user agent or platform software does not support these dimensions for scrolling, reflow is encouraged as this capability is important to people with low vision. As a reasonable benchmark, evaluate at the nearest size to what the Reflow success criterion specifies.</div>
-
 <div class="note wcag2ict software">
 
 The intent section refers to the ability for content to reflow (for vertical scrolling content at a width equivalent to 320 CSS pixels, or for horizontal scrolling content at a height equivalent to 256 CSS pixels) when user agent zooming is used to scale content or when the [viewport](#dfn-viewport) changes in width. For [non-web software](#software), this means that when users scale content, adjust the size of a window, dialog, or other resizable content area, or change the screen resolution, the content will reflow without loss of information or functionality, and without requiring scrolling in two dimensions; or that the non-web software works with platform features that satisfy this success criterion.</div>


### PR DESCRIPTION
Per @mraccess77 [comment](https://github.com/w3c/wcag2ict/issues/750#issuecomment-3185970316) on issue #750

Edit to add link to “Applying SC 1.4.10 Reflow to Non-Web Documents and Software” in [diff between November 2025 TR pub and this PR](https://services.w3.org/htmldiff?doc1=https://www.w3.org/TR/2024/NOTE-wcag2ict-22-20241115&doc2=https://deploy-preview-768--wcag2ict.netlify.app#applying-sc-1-4-10-reflow-to-non-web-documents-and-software) and [diff between 8/14 editors draft (for CFC) and this PR](https://services.w3.org/htmldiff?doc1=https://w3c.github.io/wcag2ict&doc2=https://deploy-preview-768--wcag2ict.netlify.app#applying-sc-1-4-10-reflow-to-non-web-documents-and-software).