### PR TITLE
[Editorial] Update update-wcag-json script to account for latest structure change

### DIFF
--- a/update-wcag-json.mjs
+++ b/update-wcag-json.mjs
@@ -38,7 +38,7 @@ for (const principle of data.principles) {
       delete criterion.alt_id;
       delete criterion.details;
       delete criterion.title;
-      delete criterion.techniquesHtml;
+      delete criterion.techniques;
       delete criterion.versions;
     }
   }


### PR DESCRIPTION
This updates the `update-wcag-json.mjs` script to continue to prune the fields it doesn't need, accounting for a change in the latest wcag.json format which removed `techniquesHtml` and re-added `techniques` (see w3c/wcag#4619). This update to the script isn't critical, but prevents the file from becoming bloated with a bunch of content that isn't needed for this repository.

~~I re-ran the script to confirm that this update results in no changes to wcag.json in this repository. The one change that re-running the script did produce reflects a change in the May 2025 republication of WCAG 2.1, which properly numbers the notes in 4.1.1: Parsing.~~ Update: I realized when posting this PR that my main branch was out of date. This PR causes no changes to wcag.json.