### PR TITLE
1.2.3 and 1.2.5: Add note describing audio descriptions

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -64,12 +64,6 @@ The WCAG 2 definition of “[captions](https://www.w3.org/TR/WCAG22/#dfn-caption
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.3](https://www.w3.org/WAI/WCAG22/Understanding/audio-description-or-media-alternative-prerecorded#intent).
 
 <div class="note wcag2ict">
-    
-The WCAG 2 definition of “[audio description](https://www.w3.org/TR/WCAG22/#dfn-audio-descriptions)” says that “audio description” is “also called ‘video description’ and ‘descriptive narration’”.</div>
-<div class="note wcag2ict">
-
-Secondary or alternate audio tracks are commonly used for this purpose.</div>
-<div class="note wcag2ict">
 	
 Audio descriptions (also called "video descriptions", "descriptive narration", and "described videos") add descriptive information of important visual information needed to understand the video content, including text displayed in the video. Where the main audio track of the video fully describes important visual information, audio descriptions would not be needed at all as the requirement would already be met. When audio descriptions are needed, one way to implement them is by providing a second audio track for the audio-video media.</div>
 	
@@ -93,12 +87,6 @@ The WCAG 2 definition of “[captions](https://www.w3.org/TR/WCAG22/#dfn-caption
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 1.2.5](https://www.w3.org/WAI/WCAG22/Understanding/audio-description-prerecorded#intent).
 
-<div class="note wcag2ict">
-    
-The WCAG 2 definition of “[audio description](https://www.w3.org/TR/WCAG22/#dfn-audio-descriptions)” says that audio description is “also called ‘video description’ and ‘descriptive narration’”.</div>
-<div class="note wcag2ict">
-
-Secondary or alternate audio tracks are commonly used for this purpose.</div>
 <div class="note wcag2ict">
 	
 Audio descriptions (also called "video descriptions", "descriptive narration",  and "described videos") add descriptive information of important visual information needed to understand the video content, including text displayed in the video. Where the main audio track of the video fully describes important visual information, audio descriptions would not be needed at all as the requirement would already be met. When audio descriptions are needed, one way to implement them is by providing a second audio track for the audio-video media.</div>


### PR DESCRIPTION
This originated from the EU standards work, with some adjustments that we hope will also be adopted. 

Also, removing Notes 1 and 2 as they are redundant with the new note.
See #786. 