### PR TITLE
1.4.4 Remove note regarding minimum text size

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -233,9 +233,6 @@ The [Intent section in Understanding 1.4.4 Resize Text](http://section) refers t
 For non-web software, sometimes the platform provides text scaling to 200% for most, but not all text (e.g. headings, which are naturally large, may not be increased in size to 200%, but other text does increase to 200%). In such cases, authors would only need to support text scaling to the extent provided by user settings in the platform, without losing text-size semantics, content or functionality, to satisfy this success criterion.</div>
 <div class="note wcag2ict software">
 
-For non-web software expected to be viewed at a distance of approximately 15 3/4 inches (400mm), good practice is for the default presentation for text to have an x-height that is at least as big as Arial font at 16 CSS px, which at 200% zoom would be 32 CSS px.</div>
-<div class="note wcag2ict software">
-
 See also the [Comments on Closed Functionality](#comments-on-closed-functionality).</div>
 
 ##### images-of-text


### PR DESCRIPTION
In the 2 October meeting, the group reached consensus that a note regarding minimum text size goes beyond our remit - to provide interpretation and guidance on applying WCAG 2.2. This note goes beyond the requirement of 1.4.4 Resize Text.