### PR TITLE
[Editorial] Note on 1.2.3 audio description (and 1.2.5 Note) is poor

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -89,7 +89,7 @@ This applies directly as written, and as described in [Intent from Understanding
 
 <div class="note wcag2ict">
 	
-Audio descriptions (also called "video descriptions", "descriptive narration",  and "described videos") add descriptive information of important visual information needed to understand the video content, including text displayed in the video. Where the main audio track of the video fully describes important visual information, audio descriptions would not be needed at all as the requirement would already be met. When audio descriptions are needed, one way to implement them is by providing a second audio track for the audio-video media.</div>
+Audio descriptions (also called "video descriptions", "descriptive narration",  and "described videos") describe important visual information needed to understand the video content, including text displayed in the video. Where the main audio track of the video fully describes important visual information, audio descriptions would not be needed at all as the requirement would already be met. When audio descriptions are needed, one way to implement them is by providing a second audio track for the audio-video media.</div>
 
 #### adaptable
 


### PR DESCRIPTION
Current (emphasis added):
> Audio descriptions (also called "video descriptions", "descriptive narration", and "described videos") add **descriptive information of important visual information** needed to understand the video content, including text displayed in the video.

Proposed:
> Audio descriptions (also called "video descriptions", "descriptive narration", and "described videos") add voice narration for important visual information needed to understand the video content, including text displayed in the video.

Rational:  “descriptive information ... of visual information” is quite awkward.