### PR TITLE
[Editorial] SCs 1.2.3 & 1.2.5: AWK edit 1 of 2 per Issue 812

### DIFF
--- a/comments-by-guideline-and-success-criterion.md
+++ b/comments-by-guideline-and-success-criterion.md
@@ -65,7 +65,7 @@ This applies directly as written, and as described in [Intent from Understanding
 
 <div class="note wcag2ict">
 	
-Audio descriptions (also called "video descriptions", "descriptive narration", and "described videos") add descriptive information of important visual information needed to understand the video content, including text displayed in the video. Where the main audio track of the video fully describes important visual information, audio descriptions would not be needed at all as the requirement would already be met. When audio descriptions are needed, one way to implement them is by providing a second audio track for the audio-video media.</div>
+Audio descriptions (also called "video descriptions", "descriptive narration", and "described videos") add descriptive information of important visual information needed to understand the video content, including text displayed in the video. Where the main audio track of the video fully describes important visual information, audio descriptions would not be needed at all as the requirement would already be met.  When audio descriptions are needed, one way to implement them is by providing a second audio track within the synchronized media.</div>
 	
 <div class="note wcag2ict software">
     
@@ -89,7 +89,7 @@ This applies directly as written, and as described in [Intent from Understanding
 
 <div class="note wcag2ict">
 	
-Audio descriptions (also called "video descriptions", "descriptive narration",  and "described videos") add descriptive information of important visual information needed to understand the video content, including text displayed in the video. Where the main audio track of the video fully describes important visual information, audio descriptions would not be needed at all as the requirement would already be met. When audio descriptions are needed, one way to implement them is by providing a second audio track for the audio-video media.</div>
+Audio descriptions (also called "video descriptions", "descriptive narration",  and "described videos") add descriptive information of important visual information needed to understand the video content, including text displayed in the video. Where the main audio track of the video fully describes important visual information, audio descriptions would not be needed at all as the requirement would already be met.  When audio descriptions are needed, one way to implement them is by providing a second audio track within the synchronized media.</div>
 
 #### adaptable
 


### PR DESCRIPTION
Updates comments-by-guideline-and-success-criterion replacing “audio-video” per AWK feedback to Issue #812.

Replaces “audio track for the audio-video media” with “audio track within the synchronized  media” in two places (notes to 1.2.3 and 1.2.5).