### PR TITLE
Editorial - fix 3.3.6 typo and error in level AAA order

### DIFF
--- a/comments-on-level-AAA-success-criteria.md
+++ b/comments-on-level-AAA-success-criteria.md
@@ -421,8 +421,6 @@ Guidance currently under development by the WCAG2ICT Task Force. See GitHub <a h
 
 ##### error-prevention
 
-###### Applying SC 3.3.5 Help to non-web documents and non-web software
-
 ###### Applying SC 3.3.6 Error Prevention to non-web documents and non-web software
 
 This applies directly as written, and as described in [Intent from Understanding Success Criterion 3.3.6](https://www.w3.org/WAI/WCAG22/Understanding/error-prevention-all.html#intent), replacing “Web pages that require” with “**Non-web documents and non-web software that require**”.

--- a/comments-on-level-AAA-success-criteria.md
+++ b/comments-on-level-AAA-success-criteria.md
@@ -23,8 +23,8 @@ The WCAG2ICT Task Force is in process of adding guidance for Level AAA success c
 - [2.4.8 Location](#location)
 - [2.4.9 Link Purpose (Link Only)](#link-purpose-link-only)
 - [2.4.10 Section Headings](#section-headings)
-- [3.2.5 Change on Request](#change-on-request)
 - [2.4.12 Focus Not Obscured (Enhanced)](#focus-not-obscured-enhanced)
+- [3.2.5 Change on Request](#change-on-request)
 - [3.3.6 Error Prevention (All)](#error-prevention)
 - [3.3.9 Accessible Authentication (Enhanced)](#accessible-authentication-enhanced)
 


### PR DESCRIPTION
3.3.6 typo in heading
Also corrected order of level AAA SCs in list at the start of comments on level AAA

